### PR TITLE
add isExperimental() boolean to AbstractCheck

### DIFF
--- a/src/main/java/ac/grim/grimac/api/AbstractCheck.java
+++ b/src/main/java/ac/grim/grimac/api/AbstractCheck.java
@@ -17,4 +17,6 @@ public interface AbstractCheck {
     void setEnabled(boolean enabled);
 
     void reload();
+
+    boolean isExperimental();
 }


### PR DESCRIPTION
This PR adds `isExperimental()` to GrimAPI, thus allowing to know if a check is experimental or not through the API directly.