### PR TITLE
Add silent flag to alert toggles

### DIFF
--- a/src/main/java/ac/grim/grimac/api/alerts/AlertManager.java
+++ b/src/main/java/ac/grim/grimac/api/alerts/AlertManager.java
@@ -6,6 +6,7 @@ public interface AlertManager {
 
     /**
      * Checks if the player has alerts enabled.
+     *
      * @param player
      * @return boolean
      */
@@ -13,12 +14,24 @@ public interface AlertManager {
 
     /**
      * Toggles alerts for the player.
+     *
      * @param player
      */
-    void toggleAlerts(Player player);
+    default void toggleAlerts(Player player) {
+        toggleAlerts(player, false);
+    }
+
+    /**
+     * Toggles alerts for the player.
+     *
+     * @param player
+     * @param silent - if set to true, the player won't be notified about the action
+     */
+    void toggleAlerts(Player player, boolean silent);
 
     /**
      * Checks if the player has verbose enabled.
+     *
      * @param player
      * @return boolean
      */
@@ -26,8 +39,22 @@ public interface AlertManager {
 
     /**
      * Toggles verbose for the player.
+     *
      * @param player
      */
-    void toggleVerbose(Player player);
+    default void toggleVerbose(Player player) {
+        toggleVerbose(player, false);
+    }
 
+    /**
+     * Toggles verbose for the player.
+     *
+     * @param player
+     * @param silent - if set to true, the player won't be notified about the action
+     */
+    void toggleVerbose(Player player, boolean silent);
+
+    boolean hasBrandsEnabled(Player player);
+
+    void toggleBrands(Player player, boolean silent);
 }


### PR DESCRIPTION
PR for api changes for [another PR in grim](https://github.com/GrimAnticheat/Grim/pull/1977)

If you have an idea how to make the silent flag more readable (could now be misread as the target toggle state), please suggest.

These api changes are 100% backwards compatible.