### PR TITLE
Added scope to Maven example

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ dependencies {
     <groupId>ac.grim.grimac</groupId>
     <artifactId>GrimAPI</artifactId>
     <version>%VERSION%</version>
+    <scope>provided</scope>
 </dependency>
 ```
 


### PR DESCRIPTION
Added the scope to the Maven example. Without the scope the (Plugin) Jar might include the API code bundled, which results in errors because the ClassLoader is now not matching anymore (took me way too long to notice this)