### PR TITLE
Channel-based event API (v2)

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,3 +68,100 @@ dependencies {
   <scope>provided</scope>
 </dependency>
 ```
+
+### **Subscribing to events** (1.3+)
+
+The current API dispatches each event through its own `EventChannel`. Grab the
+channel via `bus.get(EventClass.class)` and subscribe with its fluent
+`on…(…)` method. Handlers take the event's fields as positional parameters
+— no pooled event object, no class-keyed registry lookup on the hot path.
+
+Every subscribe takes a `GrimPlugin` as the first argument. The bus tracks
+subscriptions by that plugin and sweeps them automatically on plugin disable
+via `bus.unregisterAllListeners(plugin)` — same lifecycle model as Bukkit's
+`HandlerList`. Resolve the `GrimPlugin` once at plugin enable and reuse it:
+
+```java
+GrimAbstractAPI api = GrimAPIProvider.get();
+EventBus bus = api.getEventBus();
+GrimPlugin grim = api.getGrimPlugin(this);   // resolve once; `this` can be a Bukkit
+                                             // JavaPlugin, a Fabric ModContainer, etc.
+
+// Non-cancellable — observational
+bus.get(GrimTransactionSendEvent.class)
+   .onTransactionSend(grim, (user, id, ts) -> {
+       getLogger().info("tx-send " + id + " for " + user.getName());
+   });
+
+// Cancellable — returns the new cancelled state (true = cancel)
+bus.get(FlagEvent.class)
+   .onFlag(grim, (user, check, verbose, cancelled) -> {
+       if (verbose.contains("safe")) return false; // un-cancel
+       return cancelled;
+   });
+
+// Priority + ignoreCancelled overloads
+bus.get(FlagEvent.class)
+   .onFlag(grim, (u, c, v, cancelled) -> true, /*priority*/ 10, /*ignoreCancelled*/ false);
+```
+
+If you really don't want to hold a `GrimPlugin` reference, every `onX(...)`
+has a `@Deprecated` `onX(Object pluginContext, Handler, …)` overload that
+resolves the context through the bus's plugin resolver:
+
+```java
+// Works but warns. Call api.getGrimPlugin(this) once and use the
+// non-deprecated overload instead.
+bus.get(FlagEvent.class).onFlag((Object) this, (u, c, v, cancelled) -> cancelled);
+```
+
+**Cache the channel for hot paths.** The `bus.get(...)` lookup is a
+ConcurrentHashMap hit; storing the channel in a `static final` lets the JIT
+fold the lookup away entirely:
+
+```java
+public final class MyHotPathClass {
+    private static final FlagEvent.Channel FLAG =
+            GrimAPIProvider.get().getEventBus().get(FlagEvent.class);
+
+    public void process() {
+        // No map lookup, no event-object allocation.
+        FLAG.fire(user, check, verbose);
+    }
+}
+```
+
+**Priority ordering.** Lower priority fires first; higher priority gets the
+final say on cancellation. This matches Bukkit's `EventPriority`
+convention — a handler at a high priority can observe the settled cancelled
+state after lower-priority handlers have run (useful for monitoring) or,
+when registered with `ignoreCancelled = true`, override a lower-priority
+handler's cancellation by returning `false`.
+
+> **Note:** This is a direction flip from pre-1.3 Grim, which sorted
+> highest-first. Plugins migrating from 1.2.x that use explicit priority
+> numbers should re-evaluate what "early" and "late" mean for their logic.
+
+**Addon events.** Plugins that define their own `GrimEvent<Channel>`
+subclass register it once at enable with
+`bus.register(MyEvent.class, new MyEvent.Channel())`.
+
+**Plugin-disable cleanup.** `bus.unregisterAllListeners(grim)` sweeps every
+handler registered with that `GrimPlugin` — both the typed
+`bus.get(E.class).onX(grim, handler)` path and the legacy
+`bus.subscribe(ctx, E.class, listener)` / `@GrimEventHandler` paths. In
+`onDisable()`, pass either your `GrimPlugin` or the same `Object` context
+you registered with:
+
+```java
+@Override
+public void onDisable() {
+    EventBus bus = GrimAPIProvider.get().getEventBus();
+    bus.unregisterAllListeners(this);  // or: bus.unregisterAllListeners(grim)
+}
+```
+
+**Legacy API.** `bus.post(event)`, `bus.subscribe(ctx, EventClass.class, listener)`
+and `@GrimEventHandler` reflective registration are preserved for source
+compatibility with 1.2.4.0 callers, route through the same channels, and are
+marked `@Deprecated` with doc pointing at `bus.get(E.class).on…(grim, handler)`.

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,1 @@
-version = 1.2.5.0
+version = 1.3.0.0

--- a/grim-internal/build.gradle.kts
+++ b/grim-internal/build.gradle.kts
@@ -21,11 +21,19 @@ dependencies {
     compileOnly(libs.annotations)
     compileOnly(libs.lombok)
     annotationProcessor(libs.lombok)
+
+    testImplementation(libs.annotations)
+    testImplementation(libs.junitJupiter)
+    testRuntimeOnly("org.junit.platform:junit-platform-launcher")
 }
 
 tasks.withType<JavaCompile>().configureEach {
     options.release.set(17)
     options.encoding = "UTF-8"
+}
+
+tasks.test {
+    useJUnitPlatform()
 }
 
 // Publishing for the Legacy Module

--- a/grim-internal/src/main/java/ac/grim/grimac/internal/event/OptimizedEventBus.java
+++ b/grim-internal/src/main/java/ac/grim/grimac/internal/event/OptimizedEventBus.java
@@ -1,10 +1,21 @@
 package ac.grim.grimac.internal.event;
 
 import ac.grim.grimac.api.event.EventBus;
+import ac.grim.grimac.api.event.EventChannel;
 import ac.grim.grimac.api.event.GrimEvent;
 import ac.grim.grimac.api.event.GrimEventHandler;
 import ac.grim.grimac.api.event.GrimEventListener;
-import ac.grim.grimac.api.event.events.*;
+import ac.grim.grimac.api.event.events.CommandExecuteEvent;
+import ac.grim.grimac.api.event.events.CompletePredictionEvent;
+import ac.grim.grimac.api.event.events.FlagEvent;
+import ac.grim.grimac.api.event.events.GrimCheckEvent;
+import ac.grim.grimac.api.event.events.GrimJoinEvent;
+import ac.grim.grimac.api.event.events.GrimQuitEvent;
+import ac.grim.grimac.api.event.events.GrimReloadEvent;
+import ac.grim.grimac.api.event.events.GrimTeleportEvent;
+import ac.grim.grimac.api.event.events.GrimTransactionReceivedEvent;
+import ac.grim.grimac.api.event.events.GrimTransactionSendEvent;
+import ac.grim.grimac.api.event.events.GrimVerboseCheckEvent;
 import ac.grim.grimac.api.plugin.GrimPlugin;
 import ac.grim.grimac.internal.plugin.resolver.GrimExtensionManager;
 import org.jetbrains.annotations.NotNull;
@@ -14,42 +25,142 @@ import java.lang.invoke.MethodHandle;
 import java.lang.invoke.MethodHandles;
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
-import java.util.Arrays;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.IdentityHashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.atomic.AtomicReference;
-import java.util.function.Predicate;
+import java.util.concurrent.ConcurrentMap;
 
+/**
+ * Channel-backed event bus implementation.
+ *
+ * <p>All Grim built-in channels are registered explicitly at construction
+ * time — no reflection, obfuscation-safe. Addons with their own events can
+ * register via {@link #register(Class, EventChannel)}.
+ *
+ * <p>Legacy APIs ({@link #post(GrimEvent)}, class-keyed {@code subscribe},
+ * reflective {@code registerAnnotatedListeners}) are retained for source
+ * compatibility with 1.2.4.0 callers. All three route through the same
+ * channel objects as {@link #get(Class)} + the channel's typed
+ * {@code on…(…)} methods — a single post therefore reaches typed handlers
+ * as well as legacy listeners via each channel's
+ * {@link EventChannel#dispatchLegacy(GrimEvent)}.
+ */
 public class OptimizedEventBus implements EventBus {
     private final MethodHandles.Lookup lookup = MethodHandles.lookup();
     private final GrimExtensionManager extensionManager;
-    // Store all listeners together by event type
-    private final Map<Class<? extends GrimEvent>, AtomicReference<OptimizedListener[]>> listenerMap = new ConcurrentHashMap<>();
+    private final ConcurrentMap<Class<?>, EventChannel<?, ?>> channels = new ConcurrentHashMap<>();
 
+    /**
+     * Side map of reflective/class-keyed registrations keyed by identity of
+     * (pluginContext, listenerInstanceOrClass). Used by
+     * {@link #unregisterListeners(Object, Object)} and friends to find the
+     * specific entries to remove — Entry itself doesn't carry the originating
+     * listener instance. Modifications are guarded by {@code this}.
+     */
+    private final Map<Object, Map<Object, List<Registration>>> instanceRegistrations = new IdentityHashMap<>();
+
+    @SuppressWarnings({"unchecked", "rawtypes"})
     public OptimizedEventBus(GrimExtensionManager extensionManager) {
         this.extensionManager = extensionManager;
-        prefillKnownEventTypes(listenerMap);
+        // Built-in channels — direct compile-time references.
+        // Renaming any event's nested Channel breaks these lines immediately.
+
+        // Concrete channels.
+        FlagEvent.Channel flagCh                           = new FlagEvent.Channel();
+        CommandExecuteEvent.Channel commandCh              = new CommandExecuteEvent.Channel();
+        CompletePredictionEvent.Channel completeCh         = new CompletePredictionEvent.Channel();
+        GrimJoinEvent.Channel joinCh                       = new GrimJoinEvent.Channel();
+        GrimQuitEvent.Channel quitCh                       = new GrimQuitEvent.Channel();
+        GrimReloadEvent.Channel reloadCh                   = new GrimReloadEvent.Channel();
+        GrimTeleportEvent.Channel teleportCh               = new GrimTeleportEvent.Channel();
+        GrimTransactionSendEvent.Channel txSendCh          = new GrimTransactionSendEvent.Channel();
+        GrimTransactionReceivedEvent.Channel txRecvCh      = new GrimTransactionReceivedEvent.Channel();
+        installChannel(FlagEvent.class,                    flagCh);
+        installChannel(CommandExecuteEvent.class,          commandCh);
+        installChannel(CompletePredictionEvent.class,      completeCh);
+        installChannel(GrimJoinEvent.class,                joinCh);
+        installChannel(GrimQuitEvent.class,                quitCh);
+        installChannel(GrimReloadEvent.class,              reloadCh);
+        installChannel(GrimTeleportEvent.class,            teleportCh);
+        installChannel(GrimTransactionSendEvent.class,     txSendCh);
+        installChannel(GrimTransactionReceivedEvent.class, txRecvCh);
+
+        // Abstract channels. Their Class<GrimCheckEvent<?>> keys are raw-cast
+        // because GrimCheckEvent's CHANNEL type parameter is erased at .class.
+        GrimEvent.Channel anyCh                            = new GrimEvent.Channel();
+        GrimCheckEvent.Channel checkCh                     = new GrimCheckEvent.Channel();
+        GrimVerboseCheckEvent.Channel verboseCheckCh       = new GrimVerboseCheckEvent.Channel();
+        installAbstractChannel(GrimEvent.class,             anyCh);
+        installAbstractChannel(GrimCheckEvent.class,        checkCh);
+        installAbstractChannel(GrimVerboseCheckEvent.class, verboseCheckCh);
+
+        // Bridge wiring: every concrete subtype registers with every abstract
+        // parent it can bridge to. Order matters only when abstract subscribes
+        // land before registerSubtype — in that case registerSubtype walks the
+        // subscriber list. We wire after installing both channels, so at
+        // construction time the subscriber list is empty and the install is
+        // just bookkeeping.
+        checkCh.registerSubtype(FlagEvent.class,                flagCh,     FlagEvent.Channel::bridgeFromCheck);
+        checkCh.registerSubtype(CommandExecuteEvent.class,      commandCh,  CommandExecuteEvent.Channel::bridgeFromCheck);
+        checkCh.registerSubtype(CompletePredictionEvent.class,  completeCh, CompletePredictionEvent.Channel::bridgeFromCheck);
+
+        verboseCheckCh.registerSubtype(FlagEvent.class,            flagCh,    FlagEvent.Channel::bridgeFromVerboseCheck);
+        verboseCheckCh.registerSubtype(CommandExecuteEvent.class,  commandCh, CommandExecuteEvent.Channel::bridgeFromVerboseCheck);
+
+        anyCh.registerSubtype(FlagEvent.class,                    flagCh,        FlagEvent.Channel::bridgeFromAny);
+        anyCh.registerSubtype(CommandExecuteEvent.class,          commandCh,     CommandExecuteEvent.Channel::bridgeFromAny);
+        anyCh.registerSubtype(CompletePredictionEvent.class,      completeCh,    CompletePredictionEvent.Channel::bridgeFromAny);
+        anyCh.registerSubtype(GrimJoinEvent.class,                joinCh,        GrimJoinEvent.Channel::bridgeFromAny);
+        anyCh.registerSubtype(GrimQuitEvent.class,                quitCh,        GrimQuitEvent.Channel::bridgeFromAny);
+        anyCh.registerSubtype(GrimReloadEvent.class,              reloadCh,      GrimReloadEvent.Channel::bridgeFromAny);
+        anyCh.registerSubtype(GrimTeleportEvent.class,            teleportCh,    GrimTeleportEvent.Channel::bridgeFromAny);
+        anyCh.registerSubtype(GrimTransactionSendEvent.class,     txSendCh,      GrimTransactionSendEvent.Channel::bridgeFromAny);
+        anyCh.registerSubtype(GrimTransactionReceivedEvent.class, txRecvCh,      GrimTransactionReceivedEvent.Channel::bridgeFromAny);
+    }
+
+    private <E extends GrimEvent<C>, C extends EventChannel<? extends E, ?>> void installChannel(Class<E> eventClass, C channel) {
+        channel.setPluginResolver(extensionManager::getPlugin);
+        channels.put(eventClass, channel);
     }
 
     /**
-     * Minor optimization to prefill the listenerMap for known existing events so that they don't have to be computed later
-     * When registering an event of the type for the first time
-     * @param map
+     * Abstract-channel variant of {@link #installChannel}. Abstract events
+     * (GrimEvent, GrimCheckEvent, GrimVerboseCheckEvent) are generic on
+     * {@code CHANNEL}, which makes the tight
+     * {@code E extends GrimEvent<C>, C extends EventChannel<? extends E, ?>}
+     * constraint unsolvable when you pass the raw parent class with a
+     * concrete abstract-channel. Loosen the E binding here; the abstract
+     * channels are exhaustively listed in the constructor, so the looser
+     * type safety is contained.
      */
-    private void prefillKnownEventTypes(Map<Class<? extends GrimEvent>, AtomicReference<OptimizedListener[]>> map) {
-        // Add all your known event types here
-        map.put(GrimReloadEvent.class, new AtomicReference<>(new OptimizedListener[0]));
-        map.put(GrimQuitEvent.class, new AtomicReference<>(new OptimizedListener[0]));
-        map.put(GrimJoinEvent.class, new AtomicReference<>(new OptimizedListener[0]));
-
-        map.put(FlagEvent.class, new AtomicReference<>(new OptimizedListener[0]));
-        map.put(CommandExecuteEvent.class, new AtomicReference<>(new OptimizedListener[0]));
-        map.put(CompletePredictionEvent.class, new AtomicReference<>(new OptimizedListener[0]));
-
-        // Base event type
-        map.put(GrimEvent.class, new AtomicReference<>(new OptimizedListener[0]));
+    private <E, C extends EventChannel<?, ?>> void installAbstractChannel(Class<E> eventClass, C channel) {
+        channel.setPluginResolver(extensionManager::getPlugin);
+        channels.put(eventClass, channel);
     }
 
+    // ───── Typed channel API ───────────────────────────────────────────────
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public <E extends GrimEvent<C>, C extends EventChannel<? extends E, ?>> @NotNull C get(@NotNull Class<E> eventClass) {
+        EventChannel<?, ?> ch = channels.get(eventClass);
+        if (ch == null) {
+            throw new IllegalArgumentException("No EventChannel registered for " + eventClass.getName()
+                    + " — addons must call EventBus.register(Class, Channel) before first use.");
+        }
+        return (C) ch;
+    }
+
+    @Override
+    public <E extends GrimEvent<C>, C extends EventChannel<? extends E, ?>> void register(@NotNull Class<E> eventClass, @NotNull C channel) {
+        channel.setPluginResolver(extensionManager::getPlugin);
+        channels.put(eventClass, channel);
+    }
+
+    // ───── Reflective annotated-method registration ────────────────────────
 
     @Override
     public void registerAnnotatedListeners(@NotNull Object pluginContext, @NotNull Object listener) {
@@ -58,8 +169,8 @@ public class OptimizedEventBus implements EventBus {
     }
 
     @Override
-    public void registerAnnotatedListeners(GrimPlugin plugin, @NotNull Object listener) {
-        registerMethods(plugin, listener, listener.getClass());
+    public void registerAnnotatedListeners(@NotNull GrimPlugin plugin, @NotNull Object listener) {
+        registerMethods(plugin, listener, listener.getClass(), listener);
     }
 
     @Override
@@ -69,269 +180,184 @@ public class OptimizedEventBus implements EventBus {
     }
 
     @Override
-    public void registerStaticAnnotatedListeners(GrimPlugin plugin, @NotNull Class<?> clazz) {
-        registerMethods(plugin, null, clazz);
+    public void registerStaticAnnotatedListeners(@NotNull GrimPlugin plugin, @NotNull Class<?> clazz) {
+        registerMethods(plugin, null, clazz, clazz);
     }
+
+    private void registerMethods(@NotNull GrimPlugin plugin, @Nullable Object instance, @NotNull Class<?> clazz, @NotNull Object registrationKey) {
+        for (Method method : clazz.getDeclaredMethods()) {
+            GrimEventHandler annotation = method.getAnnotation(GrimEventHandler.class);
+            if (annotation == null || method.getParameterCount() != 1) continue;
+            Class<?> paramType = method.getParameterTypes()[0];
+            if (!GrimEvent.class.isAssignableFrom(paramType)) continue;
+            if (instance == null && !Modifier.isStatic(method.getModifiers())) continue;
+
+            @SuppressWarnings("unchecked")
+            Class<? extends GrimEvent<?>> eventClass = (Class<? extends GrimEvent<?>>) (Class<?>) paramType;
+            EventChannel<?, ?> channel = channels.get(eventClass);
+            if (channel == null) continue; // no channel for this event — ignore silently (matches old behavior)
+
+            try {
+                method.setAccessible(true);
+                MethodHandle handle = lookup.unreflect(method);
+                GrimEventListener<GrimEvent<?>> listener = buildListener(instance, handle);
+                subscribeLegacyInternal(plugin, channel, eventClass, listener,
+                        annotation.priority(), annotation.ignoreCancelled(), method.getDeclaringClass(), registrationKey);
+            } catch (IllegalAccessException e) {
+                e.printStackTrace();
+            }
+        }
+    }
+
+    /** Wrap a reflected method + instance as a GrimEventListener. */
+    private static GrimEventListener<GrimEvent<?>> buildListener(@Nullable Object instance, MethodHandle handle) {
+        if (instance != null) {
+            return event -> {
+                try {
+                    handle.invoke(instance, event);
+                } catch (Throwable t) {
+                    throw new RuntimeException("Failed to invoke listener for " + event.getClass().getName(), t);
+                }
+            };
+        }
+        return event -> {
+            try {
+                handle.invoke(event);
+            } catch (Throwable t) {
+                throw new RuntimeException("Failed to invoke listener for " + event.getClass().getName(), t);
+            }
+        };
+    }
+
+    // ───── Class-keyed explicit subscribe ──────────────────────────────────
+
+    @Override
+    public <T extends GrimEvent<?>> void subscribe(@NotNull Object pluginContext, @NotNull Class<T> eventType, @NotNull GrimEventListener<T> listener, int priority, boolean ignoreCancelled, @NotNull Class<?> declaringClass) {
+        GrimPlugin plugin = extensionManager.getPlugin(pluginContext);
+        subscribe(plugin, eventType, listener, priority, ignoreCancelled, declaringClass);
+    }
+
+    @Override
+    public <T extends GrimEvent<?>> void subscribe(@NotNull GrimPlugin plugin, @NotNull Class<T> eventType, @NotNull GrimEventListener<T> listener, int priority, boolean ignoreCancelled, @NotNull Class<?> declaringClass) {
+        EventChannel<?, ?> channel = channels.get(eventType);
+        if (channel == null) {
+            throw new IllegalArgumentException("No EventChannel registered for " + eventType.getName());
+        }
+        subscribeLegacyInternal(plugin, channel, eventType, listener, priority, ignoreCancelled, declaringClass, listener);
+    }
+
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    private void subscribeLegacyInternal(
+            @NotNull GrimPlugin plugin,
+            @NotNull EventChannel<?, ?> channel,
+            @NotNull Class<? extends GrimEvent<?>> eventClass,
+            @NotNull GrimEventListener<?> listener,
+            int priority, boolean ignoreCancelled,
+            @NotNull Class<?> declaringClass,
+            @NotNull Object registrationKey) {
+        ((EventChannel) channel).subscribeLegacy(listener, eventClass, priority, ignoreCancelled, plugin, declaringClass);
+        synchronized (this) {
+            Map<Object, List<Registration>> byPlugin = instanceRegistrations.computeIfAbsent(plugin, p -> new IdentityHashMap<>());
+            byPlugin.computeIfAbsent(registrationKey, k -> new ArrayList<>()).add(new Registration(channel, listener));
+        }
+    }
+
+    // ───── Unregister ──────────────────────────────────────────────────────
 
     @Override
     public void unregisterListeners(@NotNull Object pluginContext, @NotNull Object listener) {
-        GrimPlugin plugin = extensionManager.getPlugin(pluginContext);
-        unregisterListeners(plugin, listener);
-    }
-
-    private void registerMethods(GrimPlugin plugin, @Nullable Object instance, @NotNull Class<?> clazz) {
-        for (Method method : clazz.getDeclaredMethods()) {
-            GrimEventHandler annotation = method.getAnnotation(GrimEventHandler.class);
-            if (annotation != null && method.getParameterCount() == 1) {
-                Class<?> eventType = method.getParameterTypes()[0];
-                if (GrimEvent.class.isAssignableFrom(eventType)) {
-                    try {
-                        if (instance == null && !Modifier.isStatic(method.getModifiers())) {
-                            continue;
-                        }
-
-                        method.setAccessible(true);
-                        MethodHandle handle = lookup.unreflect(method);
-
-                        final GrimEventListener<GrimEvent> listener = getGrimEventListener(instance, handle, eventType);
-
-                        OptimizedListener optimizedListener = new OptimizedListener(
-                                plugin, listener, annotation.priority(),
-                                annotation.ignoreCancelled(), method.getDeclaringClass(), instance
-                        );
-
-                        addListener((Class<? extends GrimEvent>) eventType, optimizedListener);
-                    } catch (IllegalAccessException e) {
-                        e.printStackTrace();
-                    }
-                }
-            }
-        }
-    }
-
-    // Decide which listener to create at registration time to avoid the runtime 'if' check.
-    private @NotNull GrimEventListener<GrimEvent> getGrimEventListener(@Nullable Object instance, MethodHandle handle, Class<?> eventType) {
-        final GrimEventListener<GrimEvent> listener;
-        if (instance != null) {
-            // For instance methods, create a listener that captures the instance.
-            listener = event -> {
-                try {
-                    handle.invoke(instance, event);
-                } catch (Throwable throwable) {
-                    throw new RuntimeException("Failed to invoke listener for " + eventType.getName(), throwable);
-                }
-            };
-        } else {
-            // For static methods, create a listener that does NOT capture an instance.
-            // This is slightly more memory efficient and avoids the null check.
-            listener = event -> {
-                try {
-                    handle.invoke(event);
-                } catch (Throwable throwable) {
-                    throw new RuntimeException("Failed to invoke listener for " + eventType.getName(), throwable);
-                }
-            };
-        }
-        return listener;
-    }
-
-    private void addListener(Class<? extends GrimEvent> eventType, OptimizedListener newListener) {
-        AtomicReference<OptimizedListener[]> ref = listenerMap.computeIfAbsent(
-                eventType, k -> new AtomicReference<>(new OptimizedListener[0])
-        );
-
-        while (true) {
-            OptimizedListener[] oldArray = ref.get();
-
-            // Find insertion point using Arrays.binarySearch
-            // We use a comparator for descending order (higher priorities first)
-            int insertionPoint = Arrays.binarySearch(oldArray, newListener,
-                    (a, b) -> Integer.compare(b.priority, a.priority));
-
-            // If negative, convert to insertion point
-            if (insertionPoint < 0) {
-                insertionPoint = -(insertionPoint + 1);
-            } else {
-                // If we found an exact match, insert after the last equal priority element
-                // to maintain stable ordering
-                while (insertionPoint < oldArray.length - 1 &&
-                        oldArray[insertionPoint + 1].priority == newListener.priority) {
-                    insertionPoint++;
-                }
-                insertionPoint++; // Insert after the last equal priority element
-            }
-
-            OptimizedListener[] newArray = new OptimizedListener[oldArray.length + 1];
-
-            // Copy elements before insertion point
-            System.arraycopy(oldArray, 0, newArray, 0, insertionPoint);
-
-            // Insert the new listener
-            newArray[insertionPoint] = newListener;
-
-            // Copy remaining elements, shifted by one
-            System.arraycopy(oldArray, insertionPoint, newArray, insertionPoint + 1,
-                    oldArray.length - insertionPoint);
-
-            if (ref.compareAndSet(oldArray, newArray)) {
-                break;
-            }
-            // If CAS failed, loop and try again
-        }
+        unregisterListeners(extensionManager.getPlugin(pluginContext), listener);
     }
 
     @Override
-    public void unregisterListeners(GrimPlugin plugin, Object instance) {
-        for (Map.Entry<Class<? extends GrimEvent>, AtomicReference<OptimizedListener[]>> entry : listenerMap.entrySet()) {
-            removeListeners(entry.getKey(), entry.getValue(),
-                    listener -> listener.plugin.equals(plugin) &&
-                            listener.instance != null &&
-                            listener.instance.equals(instance));
-        }
+    public void unregisterListeners(@NotNull GrimPlugin plugin, @NotNull Object listener) {
+        removeInstanceRegistrations(plugin, listener);
     }
 
     @Override
     public void unregisterStaticListeners(@NotNull Object pluginContext, @NotNull Class<?> clazz) {
-        GrimPlugin plugin = extensionManager.getPlugin(pluginContext);
-        unregisterStaticListeners(plugin, clazz);
+        unregisterStaticListeners(extensionManager.getPlugin(pluginContext), clazz);
     }
 
     @Override
-    public void unregisterStaticListeners(GrimPlugin plugin, Class<?> clazz) {
-        for (Map.Entry<Class<? extends GrimEvent>, AtomicReference<OptimizedListener[]>> entry : listenerMap.entrySet()) {
-            removeListeners(entry.getKey(), entry.getValue(),
-                    listener -> listener.plugin.equals(plugin) &&
-                            listener.instance == null &&
-                            listener.declaringClass.equals(clazz));
-        }
-    }
-
-    @Override public void unregisterAllListeners(@NotNull Object pluginContext) {
-        GrimPlugin plugin = extensionManager.getPlugin(pluginContext);
-        unregisterAllListeners(plugin);
+    public void unregisterStaticListeners(@NotNull GrimPlugin plugin, @NotNull Class<?> clazz) {
+        removeInstanceRegistrations(plugin, clazz);
     }
 
     @Override
-    public void unregisterAllListeners(GrimPlugin plugin) {
-        for (Map.Entry<Class<? extends GrimEvent>, AtomicReference<OptimizedListener[]>> entry : listenerMap.entrySet()) {
-            removeListeners(entry.getKey(), entry.getValue(),
-                    listener -> listener.plugin.equals(plugin));
+    public void unregisterAllListeners(@NotNull Object pluginContext) {
+        unregisterAllListeners(extensionManager.getPlugin(pluginContext));
+    }
+
+    @Override
+    public void unregisterAllListeners(@NotNull GrimPlugin plugin) {
+        List<Registration> all = new ArrayList<>();
+        synchronized (this) {
+            Map<Object, List<Registration>> byPlugin = instanceRegistrations.remove(plugin);
+            if (byPlugin != null) {
+                for (List<Registration> regs : byPlugin.values()) all.addAll(regs);
+            }
         }
+        for (Registration r : all) r.channel.unsubscribeLegacy(r.listener);
+        for (EventChannel<?, ?> ch : channels.values()) ch.unsubscribeAllFromPlugin(plugin);
     }
 
     @Override
     public void unregisterListener(@NotNull Object pluginContext, @NotNull GrimEventListener<?> listener) {
-        GrimPlugin plugin = extensionManager.getPlugin(pluginContext);
-        unregisterListener(plugin, listener);
+        unregisterListener(extensionManager.getPlugin(pluginContext), listener);
     }
 
     @Override
-    public void unregisterListener(GrimPlugin plugin, GrimEventListener<?> eventListener) {
-        for (Map.Entry<Class<? extends GrimEvent>, AtomicReference<OptimizedListener[]>> entry : listenerMap.entrySet()) {
-            removeListeners(entry.getKey(), entry.getValue(),
-                    listener -> listener.plugin.equals(plugin) &&
-                            listener.listener.equals(eventListener));
+    public void unregisterListener(@NotNull GrimPlugin plugin, @NotNull GrimEventListener<?> listener) {
+        for (EventChannel<?, ?> ch : channels.values()) ch.unsubscribeLegacy(listener);
+        synchronized (this) {
+            Map<Object, List<Registration>> byPlugin = instanceRegistrations.get(plugin);
+            if (byPlugin != null) {
+                for (List<Registration> regs : byPlugin.values()) {
+                    regs.removeIf(r -> r.listener == listener);
+                }
+            }
         }
     }
 
-    private void removeListeners(Class<? extends GrimEvent> eventType,
-                                 AtomicReference<OptimizedListener[]> ref,
-                                 Predicate<OptimizedListener> filter) {
-        while (true) {
-            OptimizedListener[] oldArray = ref.get();
+    private void removeInstanceRegistrations(@NotNull GrimPlugin plugin, @NotNull Object key) {
+        List<Registration> toRemove;
+        synchronized (this) {
+            Map<Object, List<Registration>> byPlugin = instanceRegistrations.get(plugin);
+            if (byPlugin == null) return;
+            List<Registration> regs = byPlugin.remove(key);
+            if (regs == null) return;
+            toRemove = regs;
+        }
+        for (Registration r : toRemove) r.channel.unsubscribeLegacy(r.listener);
+    }
 
-            // Count how many listeners will remain after filtering
-            int remaining = 0;
-            for (OptimizedListener listener : oldArray) {
-                if (!filter.test(listener)) {
-                    remaining++;
-                }
-            }
+    // ───── Legacy post ─────────────────────────────────────────────────────
 
-            // If no change, return early
-            if (remaining == oldArray.length) {
-                return;
+    @Override
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    public void post(@NotNull GrimEvent<?> event) {
+        // Route to the concrete-class channel. Walks the superclass chain so a
+        // hypothetical abstract-event subscriber (via addon-registered channel)
+        // still receives the event.
+        Class<?> c = event.getClass();
+        while (c != null && GrimEvent.class.isAssignableFrom(c)) {
+            EventChannel<?, ?> ch = channels.get(c);
+            if (ch != null) {
+                ((EventChannel) ch).dispatchLegacy(event);
             }
-
-            // Create new array with filtered listeners
-            OptimizedListener[] newArray = new OptimizedListener[remaining];
-            int index = 0;
-            for (OptimizedListener listener : oldArray) {
-                if (!filter.test(listener)) {
-                    newArray[index++] = listener;
-                }
-            }
-
-            // Try to update the array
-            if (ref.compareAndSet(oldArray, newArray)) {
-                // If array is empty, remove the event type entry
-                if (newArray.length == 0) {
-                    listenerMap.remove(eventType);
-                }
-                break;
-            }
-            // If CAS failed, retry
+            c = c.getSuperclass();
         }
     }
 
-    @Override
-    public void post(@NotNull GrimEvent event) {
-        Class<?> currentEventType = event.getClass();
-        while (GrimEvent.class.isAssignableFrom(currentEventType)) {
-            AtomicReference<OptimizedListener[]> ref = listenerMap.get(currentEventType);
-            if (ref != null) {
-                // Get current array - no locking needed for reads
-                OptimizedListener[] listeners = ref.get();
-                for (OptimizedListener listener : listeners) {
-                    try {
-                        if (event.isCancelled() && !listener.ignoreCancelled) {
-                            continue;
-                        }
-                        listener.listener.handle(event);
-                    } catch (Throwable throwable) {
-                        throwable.printStackTrace();
-                    }
-                }
-            }
-            currentEventType = currentEventType.getSuperclass();
-        }
-    }
+    /** Reflective-registration bookkeeping entry. */
+    private static final class Registration {
+        final EventChannel<?, ?> channel;
+        final GrimEventListener<?> listener;
 
-    @Override
-    public <T extends GrimEvent> void subscribe(@NotNull Object pluginContext, @NotNull Class<T> eventType, @NotNull GrimEventListener<T> listener, int priority, boolean ignoreCancelled, @NotNull Class<?> declaringClass) {
-
-    }
-
-    @Override
-    public <T extends GrimEvent> void subscribe(GrimPlugin plugin, @NotNull Class<T> eventType,
-                                                @NotNull GrimEventListener<T> listener, int priority,
-                                                boolean ignoreCancelled, @NotNull Class<?> declaringClass) {
-        @SuppressWarnings("unchecked")
-        OptimizedListener optimizedListener = new OptimizedListener(
-                plugin, (GrimEventListener<GrimEvent>)listener, priority,
-                ignoreCancelled, declaringClass, null
-        );
-
-        addListener(eventType, optimizedListener);
-    }
-
-    private static class OptimizedListener {
-        final GrimPlugin plugin;
-        final GrimEventListener<GrimEvent> listener;
-        final int priority;
-        final boolean ignoreCancelled;
-        final Class<?> declaringClass;
-        final Object instance;
-
-        OptimizedListener(GrimPlugin plugin, GrimEventListener<GrimEvent> listener,
-                          int priority, boolean ignoreCancelled,
-                          Class<?> declaringClass, Object instance) {
-            this.plugin = plugin;
+        Registration(EventChannel<?, ?> channel, GrimEventListener<?> listener) {
+            this.channel = channel;
             this.listener = listener;
-            this.priority = priority;
-            this.ignoreCancelled = ignoreCancelled;
-            this.declaringClass = declaringClass;
-            this.instance = instance;
         }
     }
 }

--- a/grim-internal/src/test/java/ac/grim/grimac/internal/event/AbstractChannelBridgeTest.java
+++ b/grim-internal/src/test/java/ac/grim/grimac/internal/event/AbstractChannelBridgeTest.java
@@ -1,0 +1,176 @@
+package ac.grim.grimac.internal.event;
+
+import ac.grim.grimac.api.event.AbstractEventChannel;
+import ac.grim.grimac.api.event.EventChannel;
+import ac.grim.grimac.api.event.GrimEvent;
+import ac.grim.grimac.api.plugin.BasicGrimPlugin;
+import ac.grim.grimac.api.plugin.GrimPlugin;
+import ac.grim.grimac.internal.plugin.resolver.GrimExtensionManager;
+import org.jetbrains.annotations.NotNull;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.logging.Logger;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Covers the bridge-listener pattern that powers abstract-event subscription.
+ *
+ * <p>Uses a hand-rolled event hierarchy — an abstract {@code Animal} with two
+ * concrete subtypes {@code Dog} / {@code Cat} — so the tests don't depend on
+ * the built-in Grim event wiring.
+ */
+class AbstractChannelBridgeTest {
+
+    // ── Fixtures ───────────────────────────────────────────────────────────
+
+    /** Abstract event — never instantiated, exists only as a subscribe target. */
+    public static abstract class Animal<CHANNEL extends EventChannel<?, ?>> extends GrimEvent<CHANNEL> {
+        @FunctionalInterface
+        public interface Handler {
+            void onAnimal(@NotNull String species);
+        }
+
+        public static final class Channel extends AbstractEventChannel<Animal<?>, Handler> {
+            @SuppressWarnings({"unchecked", "rawtypes"})
+            public Channel() { super((Class<Animal<?>>) (Class) Animal.class, Handler.class); }
+
+            public void onAnimal(@NotNull GrimPlugin plugin, @NotNull Handler h) {
+                subscribeAbstract(h, 0, false, plugin);
+            }
+        }
+    }
+
+    public static final class Dog extends Animal<Dog.Channel> {
+        @FunctionalInterface
+        public interface Handler { void onDog(@NotNull String name); }
+
+        public static final class Channel extends EventChannel<Dog, Handler> {
+            public Channel() { super(Dog.class, Handler.class); }
+
+            public void onDog(@NotNull GrimPlugin plugin, @NotNull Handler h) {
+                subscribe(h, 0, false, plugin, null);
+            }
+
+            public void fire(@NotNull String name) {
+                for (Entry<Handler> e : entries()) {
+                    try { e.handler.onDog(name); } catch (Throwable t) { t.printStackTrace(); }
+                }
+            }
+
+            @Override
+            protected boolean dispatchTypedFromLegacy(@NotNull Dog event, @NotNull Handler handler, boolean cancelled) { return false; }
+
+            /** Bridge from Animal abstract subscribe. */
+            public static @NotNull Handler bridgeFromAnimal(@NotNull Animal.Handler abstractHandler) {
+                return name -> abstractHandler.onAnimal("Dog(" + name + ")");
+            }
+        }
+    }
+
+    public static final class Cat extends Animal<Cat.Channel> {
+        @FunctionalInterface
+        public interface Handler { void onCat(@NotNull String name); }
+
+        public static final class Channel extends EventChannel<Cat, Handler> {
+            public Channel() { super(Cat.class, Handler.class); }
+
+            public void onCat(@NotNull GrimPlugin plugin, @NotNull Handler h) {
+                subscribe(h, 0, false, plugin, null);
+            }
+
+            public void fire(@NotNull String name) {
+                for (Entry<Handler> e : entries()) {
+                    try { e.handler.onCat(name); } catch (Throwable t) { t.printStackTrace(); }
+                }
+            }
+
+            @Override
+            protected boolean dispatchTypedFromLegacy(@NotNull Cat event, @NotNull Handler handler, boolean cancelled) { return false; }
+
+            public static @NotNull Handler bridgeFromAnimal(@NotNull Animal.Handler abstractHandler) {
+                return name -> abstractHandler.onAnimal("Cat(" + name + ")");
+            }
+        }
+    }
+
+    private GrimPlugin plugin;
+    private Animal.Channel animalCh;
+    private Dog.Channel dogCh;
+    private Cat.Channel catCh;
+
+    @BeforeEach
+    void setUp() {
+        plugin = new BasicGrimPlugin(Logger.getLogger("t"), new File("/tmp"), "0", "", Collections.emptyList());
+        animalCh = new Animal.Channel();
+        dogCh = new Dog.Channel();
+        catCh = new Cat.Channel();
+        // Bridge tests don't need the full bus — the bridge pattern lives
+        // entirely between AbstractEventChannel and its concrete children.
+    }
+
+    // ── Non-negotiable tests ───────────────────────────────────────────────
+
+    @Test
+    void abstractSubscribeThenLateSubtypeRegister_thenFire_listenerFires() {
+        // Only Dog is wired to Animal at start. Cat will be registered AFTER
+        // the abstract subscribe.
+        animalCh.registerSubtype(Dog.class, dogCh, Dog.Channel::bridgeFromAnimal);
+
+        List<String> seen = new ArrayList<>();
+        animalCh.onAnimal(plugin, seen::add);
+
+        // Late addon subtype registration — must walk existing subscribers.
+        animalCh.registerSubtype(Cat.class, catCh, Cat.Channel::bridgeFromAnimal);
+
+        dogCh.fire("Rex");
+        catCh.fire("Whiskers");
+
+        assertEquals(List.of("Dog(Rex)", "Cat(Whiskers)"), seen);
+    }
+
+    @Test
+    void registerSubtypeThenAbstractSubscribe_thenFire_listenerFires() {
+        // All subtypes registered first.
+        animalCh.registerSubtype(Dog.class, dogCh, Dog.Channel::bridgeFromAnimal);
+        animalCh.registerSubtype(Cat.class, catCh, Cat.Channel::bridgeFromAnimal);
+
+        // Subscribe after — bridges install into every registered child.
+        List<String> seen = new ArrayList<>();
+        animalCh.onAnimal(plugin, seen::add);
+
+        dogCh.fire("Fido");
+        catCh.fire("Mittens");
+
+        assertEquals(List.of("Dog(Fido)", "Cat(Mittens)"), seen);
+    }
+
+    @Test
+    void unsubscribeFromAbstract_sweepsBridgesFromEveryConcreteChannel() {
+        animalCh.registerSubtype(Dog.class, dogCh, Dog.Channel::bridgeFromAnimal);
+        animalCh.registerSubtype(Cat.class, catCh, Cat.Channel::bridgeFromAnimal);
+
+        AtomicInteger count = new AtomicInteger();
+        Animal.Handler handler = species -> count.incrementAndGet();
+        animalCh.onAnimal(plugin, handler);
+
+        dogCh.fire("A");
+        catCh.fire("B");
+        assertEquals(2, count.get());
+
+        animalCh.unsubscribe(handler);
+
+        dogCh.fire("C");
+        catCh.fire("D");
+        assertEquals(2, count.get(), "no further hits after unsubscribe");
+        assertTrue(dogCh.isEmpty(), "dog channel has no bridges left");
+        assertTrue(catCh.isEmpty(), "cat channel has no bridges left");
+    }
+}

--- a/grim-internal/src/test/java/ac/grim/grimac/internal/event/EventChannelTest.java
+++ b/grim-internal/src/test/java/ac/grim/grimac/internal/event/EventChannelTest.java
@@ -1,0 +1,305 @@
+package ac.grim.grimac.internal.event;
+
+import ac.grim.grimac.api.event.Cancellable;
+import ac.grim.grimac.api.event.EventChannel;
+import ac.grim.grimac.api.event.GrimEvent;
+import ac.grim.grimac.api.event.GrimEventListener;
+import org.jetbrains.annotations.NotNull;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class EventChannelTest {
+
+    // ── Test fixtures ──────────────────────────────────────────────────────
+
+    /** Non-cancellable test event with a single string payload. */
+    public static class Ping extends GrimEvent<Ping.Channel> {
+        private String msg;
+
+        public Ping() {}
+
+        public Ping(String msg) { this.msg = msg; }
+
+        public void init(String msg) { resetForReuse(); this.msg = msg; }
+
+        public String getMsg() { return msg; }
+
+        @FunctionalInterface
+        public interface Handler {
+            void onPing(@NotNull String msg);
+        }
+
+        public static final class Channel extends EventChannel<Ping, Handler> {
+            private final ThreadLocal<Ping> legacyPool = ThreadLocal.withInitial(Ping::new);
+
+            public Channel() { super(Ping.class, Handler.class); }
+
+            public void onPing(@NotNull Handler h) { subscribe(h, 0, false, null, null); }
+            public void onPing(@NotNull Handler h, int priority) { subscribe(h, priority, false, null, null); }
+
+            public void fire(@NotNull String msg) {
+                Entry<Handler>[] entries = entries();
+                if (entries.length == 0) return;
+                if (!hasLegacy()) {
+                    for (Entry<Handler> e : entries) e.handler.onPing(msg);
+                    return;
+                }
+                Ping pooled = legacyPool.get();
+                pooled.init(msg);
+                for (Entry<Handler> e : entries) {
+                    if (e.legacyListener != null) {
+                        try { e.<Ping>legacyListenerAs().handle(pooled); } catch (Throwable t) { t.printStackTrace(); }
+                    } else {
+                        e.handler.onPing(msg);
+                    }
+                }
+            }
+
+            @Override
+            protected boolean dispatchTypedFromLegacy(@NotNull Ping event, @NotNull Handler handler, boolean cancelled) {
+                handler.onPing(event.getMsg());
+                return false;
+            }
+        }
+    }
+
+    /** Cancellable test event with an int payload. */
+    public static class Quest extends GrimEvent<Quest.Channel> implements Cancellable {
+        private int value;
+        private boolean cancelled;
+
+        public Quest() {}
+
+        public Quest(int value) { this.value = value; }
+
+        public void init(int value) { resetForReuse(); this.value = value; this.cancelled = false; }
+
+        public int getValue() { return value; }
+
+        @Override public boolean isCancelled() { return cancelled; }
+        @Override public void setCancelled(boolean cancelled) { this.cancelled = cancelled; }
+        @Override public boolean isCancellable() { return true; }
+
+        @FunctionalInterface
+        public interface Handler {
+            boolean onQuest(int value, boolean currentlyCancelled);
+        }
+
+        public static final class Channel extends EventChannel<Quest, Handler> {
+            private final ThreadLocal<Quest> legacyPool = ThreadLocal.withInitial(Quest::new);
+
+            public Channel() { super(Quest.class, Handler.class); }
+
+            public void onQuest(@NotNull Handler h) { subscribe(h, 0, false, null, null); }
+            public void onQuest(@NotNull Handler h, int priority, boolean ignoreCancelled) {
+                subscribe(h, priority, ignoreCancelled, null, null);
+            }
+
+            public boolean fire(int value) {
+                Entry<Handler>[] entries = entries();
+                if (entries.length == 0) return false;
+                boolean cancelled = false;
+                if (!hasLegacy()) {
+                    for (Entry<Handler> e : entries) {
+                        if (cancelled && !e.ignoreCancelled) continue;
+                        cancelled = e.handler.onQuest(value, cancelled);
+                    }
+                    return cancelled;
+                }
+                Quest pooled = legacyPool.get();
+                pooled.init(value);
+                for (Entry<Handler> e : entries) {
+                    if (cancelled && !e.ignoreCancelled) continue;
+                    if (e.legacyListener != null) {
+                        pooled.setCancelled(cancelled);
+                        try { e.<Quest>legacyListenerAs().handle(pooled); } catch (Throwable t) { t.printStackTrace(); }
+                        cancelled = pooled.isCancelled();
+                    } else {
+                        cancelled = e.handler.onQuest(value, cancelled);
+                    }
+                }
+                return cancelled;
+            }
+
+            @Override
+            protected boolean dispatchTypedFromLegacy(@NotNull Quest event, @NotNull Handler handler, boolean cancelled) {
+                return handler.onQuest(event.getValue(), cancelled);
+            }
+        }
+    }
+
+    // ── Tests ──────────────────────────────────────────────────────────────
+
+    @Test
+    void typedHandlersFireInPriorityOrderLowerFirst() {
+        Ping.Channel ch = new Ping.Channel();
+        List<String> order = new ArrayList<>();
+        ch.onPing(msg -> order.add("low"), 0);
+        ch.onPing(msg -> order.add("high"), 10);
+        ch.onPing(msg -> order.add("mid"), 5);
+
+        ch.fire("hi");
+
+        // Bukkit EventPriority order: lowest first, highest gets final say.
+        assertEquals(List.of("low", "mid", "high"), order);
+    }
+
+    @Test
+    void legacyListenerReceivesPooledEventWithCorrectFields() {
+        Ping.Channel ch = new Ping.Channel();
+        AtomicInteger hits = new AtomicInteger();
+        List<String> seen = new ArrayList<>();
+
+        GrimEventListener<Ping> listener = event -> {
+            hits.incrementAndGet();
+            seen.add(event.getMsg());
+        };
+        ch.subscribeLegacy(listener, Ping.class, 0, false, null, null);
+
+        ch.fire("first");
+        ch.fire("second");
+
+        assertEquals(2, hits.get());
+        assertEquals(List.of("first", "second"), seen);
+    }
+
+    @Test
+    void typedAndLegacyInterleavedByPriority() {
+        Ping.Channel ch = new Ping.Channel();
+        List<String> order = new ArrayList<>();
+
+        ch.onPing(msg -> order.add("typed-0"), 0);
+        ch.subscribeLegacy(e -> order.add("legacy-5"), Ping.class, 5, false, null, null);
+        ch.onPing(msg -> order.add("typed-10"), 10);
+
+        ch.fire("x");
+
+        assertEquals(List.of("typed-0", "legacy-5", "typed-10"), order);
+    }
+
+    @Test
+    void hasLegacyTogglesAsLegacyListenersComeAndGo() {
+        Ping.Channel ch = new Ping.Channel();
+        GrimEventListener<Ping> listener = e -> {};
+        assertFalse(ch.hasLegacy());
+
+        ch.subscribeLegacy(listener, Ping.class, 0, false, null, null);
+        assertTrue(ch.hasLegacy());
+
+        ch.unsubscribeLegacy(listener);
+        assertFalse(ch.hasLegacy());
+    }
+
+    @Test
+    void unsubscribeRemovesOnlyThatHandler() {
+        Ping.Channel ch = new Ping.Channel();
+        List<String> order = new ArrayList<>();
+        Ping.Handler keep = msg -> order.add("keep");
+        Ping.Handler remove = msg -> order.add("remove");
+
+        ch.onPing(keep, 0);
+        ch.onPing(remove, 0);
+
+        ch.unsubscribe(remove);
+        ch.fire("x");
+        assertEquals(List.of("keep"), order);
+    }
+
+    @Test
+    void unsubscribeAllFromPluginRemovesAllMatchingEntries() {
+        Ping.Channel ch = new Ping.Channel();
+        Object pluginA = new Object();
+        Object pluginB = new Object();
+        AtomicInteger hitsA = new AtomicInteger();
+        AtomicInteger hitsB = new AtomicInteger();
+
+        ch.subscribeLegacy(e -> hitsA.incrementAndGet(), Ping.class, 0, false, pluginA, null);
+        ch.subscribeLegacy(e -> hitsB.incrementAndGet(), Ping.class, 0, false, pluginB, null);
+
+        ch.fire("x");
+        assertEquals(1, hitsA.get());
+        assertEquals(1, hitsB.get());
+
+        ch.unsubscribeAllFromPlugin(pluginA);
+        ch.fire("x");
+        assertEquals(1, hitsA.get(), "pluginA's listener should be gone");
+        assertEquals(2, hitsB.get());
+
+        ch.unsubscribeAllFromPlugin(pluginB);
+        ch.fire("x");
+        assertEquals(2, hitsB.get());
+        assertFalse(ch.hasLegacy());
+    }
+
+    @Test
+    void cancelledEventSkipsLaterHandlersUnlessIgnoreCancelled() {
+        Quest.Channel ch = new Quest.Channel();
+        List<String> order = new ArrayList<>();
+
+        // Lowest priority fires first. A cancel at priority 0 means subsequent
+        // handlers without ignoreCancelled skip; the ignoreCancelled one still runs.
+        ch.onQuest((value, cancelled) -> { order.add("a-cancels"); return true; }, 0, false);
+        ch.onQuest((value, cancelled) -> { order.add("b-normal"); return cancelled; }, 5, false);
+        ch.onQuest((value, cancelled) -> { order.add("c-ignores"); return cancelled; }, 10, true);
+
+        boolean finalCancelled = ch.fire(42);
+
+        assertTrue(finalCancelled);
+        assertEquals(List.of("a-cancels", "c-ignores"), order);
+    }
+
+    @Test
+    void cancellationThreadedIntoSubsequentHandlers() {
+        Quest.Channel ch = new Quest.Channel();
+        List<Boolean> seen = new ArrayList<>();
+
+        // Low-priority canceller runs first; high-priority observer sees the
+        // cancelled state threaded in via the last arg.
+        ch.onQuest((value, cancelled) -> { seen.add(cancelled); return true; }, 0, false);
+        ch.onQuest((value, cancelled) -> { seen.add(cancelled); return cancelled; }, 10, true);
+
+        ch.fire(0);
+
+        assertEquals(List.of(false, true), seen);
+    }
+
+    @Test
+    void legacyListenerSeesCancellationStateViaPooledEvent() {
+        Quest.Channel ch = new Quest.Channel();
+        AtomicInteger sawCancelled = new AtomicInteger();
+
+        // Low-priority typed cancels first. High-priority legacy with
+        // ignoreCancelled=true runs after and must see cancelled=true via
+        // the pooled event.
+        ch.onQuest((value, cancelled) -> true, 0, false);
+        ch.subscribeLegacy(e -> { if (e.isCancelled()) sawCancelled.incrementAndGet(); },
+                Quest.class, 10, true, null, null);
+
+        ch.fire(0);
+
+        assertEquals(1, sawCancelled.get());
+    }
+
+    @Test
+    void dispatchLegacyInvokesBothLegacyAndTypedHandlers() {
+        Ping.Channel ch = new Ping.Channel();
+        List<String> order = new ArrayList<>();
+
+        // Legacy at priority 0 fires first; typed at priority 10 fires second.
+        ch.subscribeLegacy(e -> order.add("legacy:" + e.getMsg()), Ping.class, 0, false, null, null);
+        ch.onPing(msg -> order.add("typed:" + msg), 10);
+
+        Ping provided = new Ping("dispatched");
+        ch.dispatchLegacy(provided);
+
+        assertEquals(List.of("legacy:dispatched", "typed:dispatched"), order);
+    }
+
+}

--- a/grim-internal/src/test/java/ac/grim/grimac/internal/event/OptimizedEventBusTest.java
+++ b/grim-internal/src/test/java/ac/grim/grimac/internal/event/OptimizedEventBusTest.java
@@ -1,0 +1,210 @@
+package ac.grim.grimac.internal.event;
+
+import ac.grim.grimac.api.event.EventChannel;
+import ac.grim.grimac.api.event.GrimEvent;
+import ac.grim.grimac.api.event.GrimEventHandler;
+import ac.grim.grimac.api.event.GrimEventListener;
+import ac.grim.grimac.api.plugin.BasicGrimPlugin;
+import ac.grim.grimac.api.plugin.GrimPlugin;
+import ac.grim.grimac.internal.plugin.resolver.GrimExtensionManager;
+import org.jetbrains.annotations.NotNull;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.logging.Logger;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+
+class OptimizedEventBusTest {
+
+    // ── Fixtures ───────────────────────────────────────────────────────────
+
+    /** Test-only event to verify register/get paths for addon-defined events. */
+    public static class AddonEvent extends GrimEvent<AddonEvent.Channel> {
+        private int value;
+
+        public AddonEvent() {}
+        public AddonEvent(int value) { this.value = value; }
+        public void init(int value) { resetForReuse(); this.value = value; }
+        public int getValue() { return value; }
+
+        @FunctionalInterface
+        public interface Handler {
+            void onAddon(int value);
+        }
+
+        public static final class Channel extends EventChannel<AddonEvent, Handler> {
+            private final ThreadLocal<AddonEvent> legacyPool = ThreadLocal.withInitial(AddonEvent::new);
+
+            public Channel() { super(AddonEvent.class, Handler.class); }
+
+            public void onAddon(@NotNull Handler h) { subscribe(h, 0, false, null, null); }
+
+            public void fire(int value) {
+                Entry<Handler>[] entries = entries();
+                if (entries.length == 0) return;
+                if (!hasLegacy()) {
+                    for (Entry<Handler> e : entries) e.handler.onAddon(value);
+                    return;
+                }
+                AddonEvent pooled = legacyPool.get();
+                pooled.init(value);
+                for (Entry<Handler> e : entries) {
+                    if (e.legacyListener != null) {
+                        try { e.<AddonEvent>legacyListenerAs().handle(pooled); } catch (Throwable t) { t.printStackTrace(); }
+                    } else {
+                        e.handler.onAddon(value);
+                    }
+                }
+            }
+
+            @Override
+            protected boolean dispatchTypedFromLegacy(@NotNull AddonEvent event, @NotNull Handler handler, boolean cancelled) {
+                handler.onAddon(event.getValue());
+                return false;
+            }
+        }
+    }
+
+    /** Reflective-path listener with an annotated method. */
+    public static class ReflectiveListener {
+        final List<Integer> seen = new ArrayList<>();
+
+        @GrimEventHandler(priority = 5)
+        public void onAddon(AddonEvent event) {
+            seen.add(event.getValue());
+        }
+    }
+
+    private OptimizedEventBus bus;
+    private GrimPlugin plugin;
+
+    @BeforeEach
+    void setUp() {
+        GrimExtensionManager extensionManager = new GrimExtensionManager();
+        bus = new OptimizedEventBus(extensionManager);
+        plugin = new BasicGrimPlugin(Logger.getLogger("test"), new File("/tmp"), "0", "", Collections.emptyList());
+        // Addon events are NOT built-in; register before use.
+        bus.register(AddonEvent.class, new AddonEvent.Channel());
+    }
+
+    // ── get / register ─────────────────────────────────────────────────────
+
+    @Test
+    void getReturnsTheRegisteredChannel() {
+        AddonEvent.Channel first = bus.get(AddonEvent.class);
+        AddonEvent.Channel second = bus.get(AddonEvent.class);
+        assertSame(first, second, "bus.get must return the cached channel, not a new one per call");
+    }
+
+    // ── Typed subscribe + fire ────────────────────────────────────────────
+
+    @Test
+    void typedSubscribeAndFireWorks() {
+        AtomicInteger seen = new AtomicInteger();
+        bus.get(AddonEvent.class).onAddon(value -> seen.set(value));
+
+        bus.get(AddonEvent.class).fire(42);
+
+        assertEquals(42, seen.get());
+    }
+
+    // ── Legacy post() ──────────────────────────────────────────────────────
+
+    @Test
+    void postReachesBothLegacyAndTypedSubscribers() {
+        List<String> order = new ArrayList<>();
+        bus.get(AddonEvent.class).onAddon(value -> order.add("typed:" + value));
+        bus.subscribe(plugin, AddonEvent.class, e -> order.add("legacy:" + e.getValue()));
+
+        bus.post(new AddonEvent(7));
+
+        assertEquals(2, order.size(), "both subscribers should run");
+        assertEquals("typed:7", order.stream().filter(s -> s.startsWith("typed")).findFirst().orElseThrow());
+        assertEquals("legacy:7", order.stream().filter(s -> s.startsWith("legacy")).findFirst().orElseThrow());
+    }
+
+    @Test
+    void subscribeClassKeyedRoutesToLegacySlot() {
+        AtomicInteger seen = new AtomicInteger();
+        GrimEventListener<AddonEvent> listener = e -> seen.set(e.getValue());
+        bus.subscribe(plugin, AddonEvent.class, listener);
+
+        bus.get(AddonEvent.class).fire(99);
+
+        assertEquals(99, seen.get());
+    }
+
+    // ── Reflective registration ───────────────────────────────────────────
+
+    @Test
+    void registerAnnotatedListenersReflectsAndFires() {
+        ReflectiveListener listener = new ReflectiveListener();
+        bus.registerAnnotatedListeners(plugin, listener);
+
+        bus.get(AddonEvent.class).fire(3);
+        bus.get(AddonEvent.class).fire(4);
+
+        assertEquals(List.of(3, 4), listener.seen);
+    }
+
+    // ── Unregister ────────────────────────────────────────────────────────
+
+    @Test
+    void unregisterListenersRemovesOnlyTheMatchingInstance() {
+        ReflectiveListener a = new ReflectiveListener();
+        ReflectiveListener b = new ReflectiveListener();
+        bus.registerAnnotatedListeners(plugin, a);
+        bus.registerAnnotatedListeners(plugin, b);
+
+        bus.unregisterListeners(plugin, a);
+
+        bus.get(AddonEvent.class).fire(1);
+
+        assertEquals(Collections.emptyList(), a.seen);
+        assertEquals(List.of(1), b.seen);
+    }
+
+    @Test
+    void unregisterListenerByListenerObject() {
+        AtomicInteger seen = new AtomicInteger();
+        GrimEventListener<AddonEvent> listener = e -> seen.incrementAndGet();
+        bus.subscribe(plugin, AddonEvent.class, listener);
+
+        bus.get(AddonEvent.class).fire(1);
+        assertEquals(1, seen.get());
+
+        bus.unregisterListener(plugin, listener);
+        bus.get(AddonEvent.class).fire(2);
+        assertEquals(1, seen.get(), "listener should not fire after unregistration");
+    }
+
+    @Test
+    void unregisterAllListenersSweepsPluginFromEveryChannel() {
+        AtomicInteger a = new AtomicInteger();
+        AtomicInteger b = new AtomicInteger();
+
+        // Subscribe legacy + via annotated method (separate channels not needed — same one suffices).
+        bus.subscribe(plugin, AddonEvent.class, e -> a.incrementAndGet());
+        bus.registerAnnotatedListeners(plugin, new Object() {
+            @GrimEventHandler
+            public void onAddon(AddonEvent event) { b.incrementAndGet(); }
+        });
+
+        bus.get(AddonEvent.class).fire(0);
+        assertEquals(1, a.get());
+        assertEquals(1, b.get());
+
+        bus.unregisterAllListeners(plugin);
+        bus.get(AddonEvent.class).fire(0);
+        assertEquals(1, a.get(), "class-keyed subscribe should be swept");
+        assertEquals(1, b.get(), "reflective subscribe should be swept");
+    }
+
+}

--- a/libs.versions.toml
+++ b/libs.versions.toml
@@ -3,11 +3,13 @@ lombok = "1.18.42"
 annotations = "24.1.0"
 spigot = "1.18-R0.1-SNAPSHOT"
 indraGit = "4.0.0"
+junit = "5.11.3"
 
 [libraries]
 lombok = { module = "org.projectlombok:lombok", version.ref = "lombok" }
 annotations = { module = "org.jetbrains:annotations", version.ref = "annotations" }
 spigotApi = { module = "org.spigotmc:spigot-api", version.ref = "spigot" }
+junitJupiter = { module = "org.junit.jupiter:junit-jupiter", version.ref = "junit" }
 
 [plugins]
 indraGit = { id = "net.kyori.indra.git", version.ref = "indraGit" }

--- a/src/main/java/ac/grim/grimac/api/event/AbstractEventChannel.java
+++ b/src/main/java/ac/grim/grimac/api/event/AbstractEventChannel.java
@@ -1,0 +1,183 @@
+package ac.grim.grimac.api.event;
+
+import ac.grim.grimac.api.plugin.GrimPlugin;
+import org.jetbrains.annotations.ApiStatus;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.function.Function;
+
+/**
+ * Coordinator for subscribing to an <em>abstract</em> event type that has
+ * multiple concrete subtypes — e.g. {@link ac.grim.grimac.api.event.events.GrimCheckEvent}
+ * dispatches through {@code FlagEvent}, {@code CompletePredictionEvent}, and
+ * {@code CommandExecuteEvent}.
+ *
+ * <p>The implementation uses the <b>bridge-listener</b> pattern: an
+ * abstract subscribe installs one concrete-typed <i>bridge</i> entry into
+ * every registered child channel. The hot path ({@code child.fire(...)})
+ * iterates its entries as normal — bridges are indistinguishable from
+ * direct typed subscribers for sort order, priority, and cancellation. No
+ * extra dispatch logic on fire.
+ *
+ * <p>Late-registered subtypes are covered: {@link #registerSubtype} walks
+ * the abstract-subscriber list and installs bridges on the newly-added
+ * child channel. Unsubscribing an abstract handler sweeps every bridge it
+ * installed across all concrete channels.
+ *
+ * <h2>Addon authors</h2>
+ * A subclass of an abstract event (e.g. a custom check type extending
+ * {@code GrimCheckEvent}) must opt in so it receives abstract-level
+ * dispatches. After {@code bus.register(MyEvent.class, myChannel)}:
+ *
+ * <pre>{@code
+ * GrimCheckEvent.Channel abs = (GrimCheckEvent.Channel) bus.get(GrimCheckEvent.class);
+ * abs.registerSubtype(MyEvent.class, myChannel, MyEvent.Channel::bridgeFromCheck);
+ * }</pre>
+ *
+ * @param <E> the abstract event type
+ * @param <H> the abstract handler type
+ */
+public abstract class AbstractEventChannel<E extends GrimEvent<?>, H> extends EventChannel<E, H> {
+
+    /** Live subscribers at this abstract level. Never iterated on the hot path. */
+    private final List<AbstractSub<H>> abstractSubs = new CopyOnWriteArrayList<>();
+
+    /** Registered concrete subtype → (child channel, bridge factory). */
+    private final Map<Class<? extends E>, ChildEntry<H, ?>> children = new ConcurrentHashMap<>();
+
+    protected AbstractEventChannel(@NotNull Class<E> eventClass, @NotNull Class<H> handlerType) {
+        super(eventClass, handlerType);
+    }
+
+    /**
+     * Register a concrete subtype with this abstract channel so any current
+     * and future abstract subscribers receive bridged dispatches when the
+     * concrete channel fires. Safe to call either before or after abstract
+     * subscribers are added — {@code registerSubtype} installs bridges for
+     * every subscriber already on the list.
+     *
+     * @param concreteType    the subtype's {@code Class}
+     * @param concreteChannel the subtype's channel
+     * @param bridgeFactory   converts an abstract {@code H} handler into a
+     *                        concrete handler that, when invoked by the
+     *                        concrete channel's fire, calls back into the
+     *                        abstract handler with the shared fields
+     */
+    @ApiStatus.Internal
+    public <CH> void registerSubtype(@NotNull Class<? extends E> concreteType,
+                                     @NotNull EventChannel<?, CH> concreteChannel,
+                                     @NotNull Function<H, CH> bridgeFactory) {
+        ChildEntry<H, CH> entry = new ChildEntry<>(concreteChannel, bridgeFactory);
+        children.put(concreteType, entry);
+        for (AbstractSub<H> sub : abstractSubs) {
+            installBridge(sub, entry);
+        }
+    }
+
+    /**
+     * Protected entry point used by subclass {@code on…(…)} methods — adds
+     * the handler to the abstract subscriber list and installs a bridge
+     * entry on every currently-registered concrete child channel.
+     */
+    protected final void subscribeAbstract(@NotNull H handler, int priority, boolean ignoreCancelled,
+                                           @Nullable Object pluginContext) {
+        AbstractSub<H> sub = new AbstractSub<>(handler, pluginContext, priority, ignoreCancelled);
+        abstractSubs.add(sub);
+        for (ChildEntry<H, ?> entry : children.values()) {
+            installBridge(sub, entry);
+        }
+    }
+
+    /**
+     * Resolves a platform-specific context ({@link Object}) into a
+     * {@link GrimPlugin} using the resolver installed by the bus, then
+     * delegates to the plugin-bound overload. Matches the behaviour of
+     * {@link EventChannel#resolvePlugin(Object)} on concrete channels.
+     */
+    protected final void subscribeAbstractResolving(@NotNull Object pluginContext, @NotNull H handler,
+                                                    int priority, boolean ignoreCancelled) {
+        subscribeAbstract(handler, priority, ignoreCancelled, resolvePlugin(pluginContext));
+    }
+
+    /**
+     * Removes the given abstract handler and sweeps every bridge it
+     * installed across all concrete child channels.
+     */
+    @Override
+    public void unsubscribe(@NotNull H handler) {
+        AbstractSub<H> target = null;
+        synchronized (abstractSubs) {
+            for (AbstractSub<H> sub : abstractSubs) {
+                if (sub.handler == handler) { target = sub; break; }
+            }
+            if (target == null) return;
+            abstractSubs.remove(target);
+        }
+        for (Bridge b : target.bridges) b.sweep();
+    }
+
+    /**
+     * Unreachable — an abstract channel holds no direct entries, so
+     * {@link EventChannel#dispatchLegacy(GrimEvent)} on it always iterates
+     * an empty array. The legacy dispatch reaches subscribers via the
+     * bridges installed in each concrete child channel.
+     */
+    @Override
+    protected final boolean dispatchTypedFromLegacy(@NotNull E event, @NotNull H handler, boolean cancelled) {
+        throw new UnsupportedOperationException(
+                "AbstractEventChannel has no direct entries — bridges dispatch through concrete children");
+    }
+
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    private <CH> void installBridge(AbstractSub<H> sub, ChildEntry<H, CH> entry) {
+        CH bridgeHandler = entry.bridgeFactory.apply(sub.handler);
+        ((EventChannel) entry.channel).subscribeTyped(bridgeHandler, sub.priority, sub.ignoreCancelled, sub.pluginContext);
+        sub.bridges.add(new Bridge(entry.channel, bridgeHandler));
+    }
+
+    private static final class AbstractSub<H> {
+        final H handler;
+        final @Nullable Object pluginContext;
+        final int priority;
+        final boolean ignoreCancelled;
+        final List<Bridge> bridges = new ArrayList<>();
+
+        AbstractSub(H handler, @Nullable Object pluginContext, int priority, boolean ignoreCancelled) {
+            this.handler = handler;
+            this.pluginContext = pluginContext;
+            this.priority = priority;
+            this.ignoreCancelled = ignoreCancelled;
+        }
+    }
+
+    private static final class Bridge {
+        final EventChannel<?, ?> channel;
+        final Object handler;
+
+        Bridge(EventChannel<?, ?> channel, Object handler) {
+            this.channel = channel;
+            this.handler = handler;
+        }
+
+        @SuppressWarnings({"unchecked", "rawtypes"})
+        void sweep() {
+            ((EventChannel) channel).unsubscribe(handler);
+        }
+    }
+
+    private static final class ChildEntry<H, CH> {
+        final EventChannel<?, CH> channel;
+        final Function<H, CH> bridgeFactory;
+
+        ChildEntry(EventChannel<?, CH> channel, Function<H, CH> bridgeFactory) {
+            this.channel = channel;
+            this.bridgeFactory = bridgeFactory;
+        }
+    }
+}

--- a/src/main/java/ac/grim/grimac/api/event/EventBus.java
+++ b/src/main/java/ac/grim/grimac/api/event/EventBus.java
@@ -1,244 +1,217 @@
 package ac.grim.grimac.api.event;
 
 import ac.grim.grimac.api.plugin.GrimPlugin;
+import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
 
 /**
- * Event bus for registering and dispatching Grim events.
- * <p>
- * This bus supports both reflective (annotation-based) and explicit (manual) registration of listeners.
- * All registration and unregistration methods require a {@code pluginContext} object. This object is used to
- * manage the listener's lifecycle, automatically unregistering listeners when the associated plugin or extension is disabled.
- * <p>
- * <b>Providing a Plugin Context:</b>
- * <ul>
- *   <li><b>For Platform Plugins (Bukkit, Fabric, etc.):</b> Pass your main plugin/mod instance (e.g., {@code this} from
- *       your {@code JavaPlugin} class). The API will resolve it automatically.</li>
- *   <li><b>For Standalone Extensions:</b> Manually create a {@link GrimPlugin} instance and pass it directly.</li>
- * </ul>
+ * Grim's event bus.
+ *
+ * <h2>Recommended use — channel-based subscribe and fire</h2>
+ * {@link #get(Class) bus.get(EventClass.class)} returns the event's typed
+ * {@link EventChannel}. Subscribe through the channel's fluent {@code onX(...)}
+ * methods and fire (internally) through its {@code fire(...)} method — dispatch
+ * is zero-allocation on the hot path and invokes handlers in priority order.
+ *
+ * <pre>{@code
+ * // Subscribe
+ * EventBus bus = GrimAPIProvider.getAPI().getEventBus();
+ * bus.get(FlagEvent.class).onFlag((user, check, verbose, cancelled) -> {
+ *     getLogger().info("flag " + check.getClass().getSimpleName());
+ *     return cancelled;
+ * });
+ *
+ * // Hot-path: cache the channel in a static final
+ * private static final FlagEvent.Channel FLAG =
+ *     GrimAPI.INSTANCE.getEventBus().get(FlagEvent.class);
+ * // then FLAG.fire(user, check, verbose);
+ * }</pre>
+ *
+ * <h2>Legacy API (deprecated)</h2>
+ * The class-keyed {@code subscribe(...)}, {@code post(...)}, and reflective
+ * {@code registerAnnotatedListeners(...)} methods are preserved for source
+ * compatibility with pre-1.3 callers. Internally they route through the same
+ * {@link EventChannel}s as the typed API — a {@code post(legacyEvent)} reaches
+ * both legacy-registered listeners AND typed handlers (via the channel's
+ * unpack path).
  */
 public interface EventBus {
 
+    // ───── Typed channel API (recommended) ─────────────────────────────────
+
     /**
-     * Registers instance methods annotated with {@link GrimEventHandler} as event listeners.
-     * This method is provided for convenience and has performance and memory usage overhead.
-     * It is recommended you use {@link EventBus#subscribe(Object, Class, GrimEventListener)} instead.
-     * <p><b>Example (Bukkit Plugin):</b>
-     * <pre>{@code
-     * // In your main plugin/mod class that extends JavaPlugin or implements ModContainer
-     * eventBus.registerAnnotatedListeners(this, new MyListener());
-     * }</pre>
+     * Returns the {@link EventChannel} for the given event class. Callers
+     * should cache the returned reference (e.g. in a {@code static final}
+     * field) so the hot-path fire/subscribe call is a direct virtual dispatch
+     * rather than a registry lookup.
      *
-     * @param pluginContext The context (e.g., Bukkit Plugin, Fabric Mod, GrimPlugin) to bind listeners to.
-     * @param listener The listener instance containing annotated methods.
+     * <p>The returned channel is stable for the life of the bus.
+     *
+     * @param eventClass the event's own {@code Class} object
+     * @param <E>        the event type
+     * @param <C>        the channel subclass associated with {@code E}, inferred via {@code E extends GrimEvent<C>}
      */
+    <E extends GrimEvent<C>, C extends EventChannel<? extends E, ?>> @NotNull C get(@NotNull Class<E> eventClass);
+
+    /**
+     * Registers a channel for an event type not known at bus construction
+     * time. Addons that define their own {@link GrimEvent} subclass with a
+     * nested {@link EventChannel} must call this once at startup so
+     * {@link #get(Class)} can find their channel.
+     *
+     * <p>Calling {@code register} twice for the same event class replaces
+     * the previous channel (any subscribers on the old channel are lost).
+     *
+     * @param eventClass the event's {@code Class} object
+     * @param channel    the addon's channel instance
+     */
+    <E extends GrimEvent<C>, C extends EventChannel<? extends E, ?>> void register(@NotNull Class<E> eventClass, @NotNull C channel);
+
+    // ───── Reflective annotated-method registration (deprecated) ───────────
+
+    /**
+     * @deprecated Prefer {@code bus.get(EventClass.class).onX((...) -> ...)}.
+     * Typed subscribes avoid the reflection pass, the per-invocation pooled
+     * event instance, and the indirection through {@link GrimEventListener}.
+     * This method is retained for source compatibility with 1.2.4.0 callers;
+     * annotated methods are registered as legacy listeners on the matching
+     * event's channel.
+     */
+    @Deprecated
     void registerAnnotatedListeners(@NotNull Object pluginContext, @NotNull Object listener);
 
     /**
-     * Registers instance methods annotated with {@link GrimEventHandler} using an explicit {@link GrimPlugin} instance.
-     * This is useful for standalone extensions or when you have already resolved a context.
-     *
-     * @param plugin   The GrimPlugin instance to bind listeners to.
-     * @param listener The listener instance containing annotated methods.
+     * @deprecated See {@link #registerAnnotatedListeners(Object, Object)}.
      */
+    @Deprecated
     void registerAnnotatedListeners(@NotNull GrimPlugin plugin, @NotNull Object listener);
 
-
     /**
-     * Registers static methods annotated with {@link GrimEventHandler} as event listeners.
-     *
-     * <p>
-     * Example:
-     * <pre>{@code
-     * public class MyStaticListener {
-     *     @GrimEventHandler(priority = 1, ignoreCancelled = true)
-     *     public static void onFlag(FlagEvent event) {
-     *         // Handle flag
-     *     }
-     * }
-     * eventBus.registerStaticAnnotatedListeners(this, MyStaticListener.class);
-     * }</pre>
-     *
-     * @param pluginContext The context to bind listeners to.
-     * @param clazz  The class containing static annotated methods.
+     * @deprecated See {@link #registerAnnotatedListeners(Object, Object)}.
      */
+    @Deprecated
     void registerStaticAnnotatedListeners(@NotNull Object pluginContext, @NotNull Class<?> clazz);
 
     /**
-     * Registers static methods annotated with {@link GrimEventHandler} using an explicit {@link GrimPlugin} instance.
-     *
-     * <p>
-     * Example:
-     * <pre>{@code
-     * public class MyStaticListener {
-     *     @GrimEventHandler(priority = 1, ignoreCancelled = true)
-     *     public static void onFlag(FlagEvent event) {
-     *         // Handle flag
-     *     }
-     * }
-     * eventBus.registerStaticAnnotatedListeners(plugin, MyStaticListener.class);
-     * }</pre>
-     *
-     * @param plugin The GrimPlugin instance to bind listeners to.
-     * @param clazz  The class containing static annotated methods.
+     * @deprecated See {@link #registerAnnotatedListeners(Object, Object)}.
      */
+    @Deprecated
     void registerStaticAnnotatedListeners(@NotNull GrimPlugin plugin, @NotNull Class<?> clazz);
 
     /**
-     * Unregisters all instance listeners associated with the given listener object and its plugin context.
-     *
-     * @param pluginContext The context the listener was registered with.
-     * @param listener The listener instance to unregister.
+     * @deprecated Use the handle returned from the channel's
+     * {@code onX(...)} subscribe to unsubscribe, or cache the handler lambda
+     * and call {@code channel.unsubscribe(lambda)}.
      */
+    @Deprecated
     void unregisterListeners(@NotNull Object pluginContext, @NotNull Object listener);
 
     /**
-     * Unregisters all instance listeners associated with an explicit {@link GrimPlugin} instance.
-     *
-     * @param plugin   The GrimPlugin the listener was registered with.
-     * @param listener The listener instance to unregister.
+     * @deprecated See {@link #unregisterListeners(Object, Object)}.
      */
+    @Deprecated
     void unregisterListeners(@NotNull GrimPlugin plugin, @NotNull Object listener);
 
-
     /**
-     * Unregisters all static listeners associated with the given class and its plugin context.
-     *
-     * @param pluginContext The context the listener was registered with.
-     * @param clazz  The class containing static listeners to unregister.
+     * @deprecated See {@link #unregisterListeners(Object, Object)}.
      */
+    @Deprecated
     void unregisterStaticListeners(@NotNull Object pluginContext, @NotNull Class<?> clazz);
 
     /**
-     * Unregisters all static listeners associated with an explicit {@link GrimPlugin} instance.
-     *
-     * @param plugin The GrimPlugin the listener was registered with.
-     * @param clazz  The class containing static listeners to unregister.
+     * @deprecated See {@link #unregisterListeners(Object, Object)}.
      */
+    @Deprecated
     void unregisterStaticListeners(@NotNull GrimPlugin plugin, @NotNull Class<?> clazz);
 
-
     /**
-     * Unregisters all listeners (reflective and explicit) associated with the given plugin context.
-     * This is typically called automatically by GrimAC when a plugin is disabled.
-     *
-     * @param pluginContext The context to unregister all listeners for.
+     * Unregisters every subscriber — typed OR legacy — bound to the given
+     * plugin context. Called automatically by GrimAC on plugin disable; plugin
+     * authors shouldn't normally need this.
      */
     void unregisterAllListeners(@NotNull Object pluginContext);
 
     /**
-     * Unregisters all listeners associated with an explicit {@link GrimPlugin} instance.
-     *
-     * @param plugin The GrimPlugin to unregister all listeners for.
+     * See {@link #unregisterAllListeners(Object)}.
      */
     void unregisterAllListeners(@NotNull GrimPlugin plugin);
 
-
     /**
-     * Unregisters a specific explicit listener associated with the given plugin context.
-     *
-     * @param pluginContext The context the listener was registered with.
-     * @param listener The explicit listener to unregister.
+     * @deprecated See {@link #unregisterListeners(Object, Object)}.
      */
+    @Deprecated
     void unregisterListener(@NotNull Object pluginContext, @NotNull GrimEventListener<?> listener);
 
     /**
-     * Unregisters a specific explicit listener associated with an explicit {@link GrimPlugin} instance.
-     *
-     * @param plugin   The GrimPlugin the listener was registered with.
-     * @param listener The explicit listener to unregister.
+     * @deprecated See {@link #unregisterListener(Object, GrimEventListener)}.
      */
+    @Deprecated
     void unregisterListener(@NotNull GrimPlugin plugin, @NotNull GrimEventListener<?> listener);
 
-    /**
-     * Posts an event to all registered listeners.
-     *
-     * @param event The event to post.
-     */
-    void post(@NotNull GrimEvent event);
+    // ───── Class-keyed post + subscribe (deprecated) ───────────────────────
 
     /**
-     * Subscribes an explicit listener to the specified event type.
-     * <p><b>Example:</b>
-     * <pre>{@code
-     * // From a Bukkit Plugin, using 'this' as the context
-     * eventBus.subscribe(this, FlagEvent.class, this::onFlag, 1, true, getClass());
-     * }</pre>
+     * Posts a {@link GrimEvent} through the bus. Invokes both legacy-registered
+     * listeners (via {@link GrimEventListener#handle(GrimEvent)}) and typed
+     * handlers (by unpacking the event's fields into the Handler's positional
+     * params) in ascending priority order — lower-priority subscribers fire
+     * first, higher-priority subscribers get the final say on cancellation.
+     * This is the Bukkit / Paper convention and a direction flip relative to
+     * pre-1.3 Grim, which sorted highest-first. Callers that set explicit
+     * priority numbers should re-evaluate them when moving from 1.2.x to 1.3+.
      *
-     * @param pluginContext   The context to bind the listener to.
-     * @param eventType       The event type to listen for.
-     * @param listener        The listener to handle the event.
-     * @param priority        The priority (higher = earlier execution).
-     * @param ignoreCancelled Whether to ignore cancelled events.
-     * @param declaringClass  The class declaring the listener (for unregistration purposes).
-     * @param <T>             The event type.
+     * @deprecated Internal Grim firings should use the channel's typed
+     * {@code fire(...)} directly — it avoids the caller-side event instance
+     * allocation. This method is retained for source compatibility with
+     * 1.2.4.0 callers that build event instances themselves.
      */
-    <T extends GrimEvent> void subscribe(@NotNull Object pluginContext, @NotNull Class<T> eventType, @NotNull GrimEventListener<T> listener, int priority, boolean ignoreCancelled, @NotNull Class<?> declaringClass);
+    @ApiStatus.Internal
+    @Deprecated
+    void post(@NotNull GrimEvent<?> event);
 
     /**
-     * Subscribes an explicit listener using an explicit {@link GrimPlugin} instance.
-     *
-     * @param plugin          The GrimPlugin instance to bind the listener to.
-     * @param eventType       The event type to listen for.
-     * @param listener        The listener to handle the event.
-     * @param priority        The priority of the listener.
-     * @param ignoreCancelled Whether to ignore cancelled events.
-     * @param declaringClass  The class declaring the listener (for unregistration purposes).
-     * @param <T>             The event type.
+     * @deprecated Prefer {@code bus.get(EventClass.class).onX(...)} — it
+     * subscribes a typed handler directly, avoiding the per-dispatch pooled
+     * event instance and the class-keyed lookup on every {@code post(...)}.
      */
-    <T extends GrimEvent> void subscribe(@NotNull GrimPlugin plugin, @NotNull Class<T> eventType, @NotNull GrimEventListener<T> listener, int priority, boolean ignoreCancelled, @NotNull Class<?> declaringClass);
-
+    @Deprecated
+    <T extends GrimEvent<?>> void subscribe(@NotNull Object pluginContext, @NotNull Class<T> eventType, @NotNull GrimEventListener<T> listener, int priority, boolean ignoreCancelled, @NotNull Class<?> declaringClass);
 
     /**
-     * Subscribes an explicit listener, using the listener's own class as the declaring class.
-     *
-     * @param pluginContext   The context to bind the listener to.
-     * @param eventType       The event type to listen for.
-     * @param listener        The listener to handle the event.
-     * @param priority        The priority of the listener.
-     * @param ignoreCancelled Whether to ignore cancelled events.
-     * @param <T>             The event type.
+     * @deprecated See {@link #subscribe(Object, Class, GrimEventListener, int, boolean, Class)}.
      */
-    default <T extends GrimEvent> void subscribe(@NotNull Object pluginContext, @NotNull Class<T> eventType, @NotNull GrimEventListener<T> listener, int priority, boolean ignoreCancelled) {
+    @Deprecated
+    <T extends GrimEvent<?>> void subscribe(@NotNull GrimPlugin plugin, @NotNull Class<T> eventType, @NotNull GrimEventListener<T> listener, int priority, boolean ignoreCancelled, @NotNull Class<?> declaringClass);
+
+    /**
+     * @deprecated See {@link #subscribe(Object, Class, GrimEventListener, int, boolean, Class)}.
+     */
+    @Deprecated
+    default <T extends GrimEvent<?>> void subscribe(@NotNull Object pluginContext, @NotNull Class<T> eventType, @NotNull GrimEventListener<T> listener, int priority, boolean ignoreCancelled) {
         subscribe(pluginContext, eventType, listener, priority, ignoreCancelled, listener.getClass());
     }
 
     /**
-     * Subscribes an explicit listener with a default declaring class.
-     *
-     * @param plugin          The GrimPlugin instance to bind the listener to.
-     * @param eventType       The event type to listen for.
-     * @param listener        The listener to handle the event.
-     * @param priority        The priority of the listener.
-     * @param ignoreCancelled Whether to ignore cancelled events.
-     * @param <T>             The event type.
+     * @deprecated See {@link #subscribe(Object, Class, GrimEventListener, int, boolean, Class)}.
      */
-    default <T extends GrimEvent> void subscribe(@NotNull GrimPlugin plugin, @NotNull Class<T> eventType, @NotNull GrimEventListener<T> listener, int priority, boolean ignoreCancelled) {
+    @Deprecated
+    default <T extends GrimEvent<?>> void subscribe(@NotNull GrimPlugin plugin, @NotNull Class<T> eventType, @NotNull GrimEventListener<T> listener, int priority, boolean ignoreCancelled) {
         subscribe(plugin, eventType, listener, priority, ignoreCancelled, listener.getClass());
     }
 
-
     /**
-     * Subscribes an explicit listener with default priority (0) and ignoreCancelled (false).
-     *
-     * @param pluginContext   The context to bind the listener to.
-     * @param eventType       The event type to listen for.
-     * @param listener        The listener to handle the event.
-     * @param <T>             The event type.
+     * @deprecated See {@link #subscribe(Object, Class, GrimEventListener, int, boolean, Class)}.
      */
-    default <T extends GrimEvent> void subscribe(@NotNull Object pluginContext, @NotNull Class<T> eventType, @NotNull GrimEventListener<T> listener) {
+    @Deprecated
+    default <T extends GrimEvent<?>> void subscribe(@NotNull Object pluginContext, @NotNull Class<T> eventType, @NotNull GrimEventListener<T> listener) {
         subscribe(pluginContext, eventType, listener, 0, false);
     }
 
     /**
-     * Subscribes an explicit listener with default priority and ignoreCancelled settings.
-     *
-     * @param plugin    The GrimPlugin instance to bind the listener to.
-     * @param eventType The event type to listen for.
-     * @param listener  The listener to handle the event.
-     * @param <T>       The event type.
+     * @deprecated See {@link #subscribe(Object, Class, GrimEventListener, int, boolean, Class)}.
      */
-    default <T extends GrimEvent> void subscribe(@NotNull GrimPlugin plugin, @NotNull Class<T> eventType, @NotNull GrimEventListener<T> listener) {
+    @Deprecated
+    default <T extends GrimEvent<?>> void subscribe(@NotNull GrimPlugin plugin, @NotNull Class<T> eventType, @NotNull GrimEventListener<T> listener) {
         subscribe(plugin, eventType, listener, 0, false);
     }
 }

--- a/src/main/java/ac/grim/grimac/api/event/EventChannel.java
+++ b/src/main/java/ac/grim/grimac/api/event/EventChannel.java
@@ -1,0 +1,325 @@
+package ac.grim.grimac.api.event;
+
+import ac.grim.grimac.api.plugin.GrimPlugin;
+import org.jetbrains.annotations.ApiStatus;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.Arrays;
+
+/**
+ * Per-event subscriber registry and dispatch primitive.
+ *
+ * <p>Every event defines its own {@code EventChannel} subclass that adds a
+ * typed {@code fire(...)} method taking the event's parameters directly.
+ * Dispatch is zero-allocation on the hot path: the volatile subscriber array
+ * is pre-sorted by ascending priority (lower fires first, higher gets the
+ * final say on cancellation — Bukkit {@code EventPriority} convention), the
+ * typed handler is invoked through a SAM interface without wrapping the call
+ * in a {@code GrimEvent} object, and the legacy pooled-event pathway is
+ * skipped entirely when no legacy subscriber is attached.
+ *
+ * <h2>Subscriber kinds</h2>
+ * A channel stores a single copy-on-write {@link Entry} array. Each entry is
+ * either:
+ * <ul>
+ *   <li><b>typed</b> — holds an {@code H} handler. Dispatched by calling the
+ *       handler directly with primitive/reference parameters.</li>
+ *   <li><b>legacy</b> — holds a {@link GrimEventListener} bound to the event's
+ *       {@code GrimEvent} subclass. Dispatched by populating a per-thread
+ *       pooled event instance and invoking the listener.</li>
+ * </ul>
+ *
+ * <h2>Threading</h2>
+ * {@code subscribe} / {@code unsubscribe} mutations swap the array under a
+ * monitor and are safe to call concurrently with {@link #entries()} and with
+ * in-flight {@code fire(...)} calls from other threads. The array itself is
+ * never mutated after publication.
+ *
+ * <h2>Cancellation</h2>
+ * The base class is cancellation-agnostic. Subclasses for cancellable events
+ * thread a {@code boolean cancelled} through their dispatch loop themselves;
+ * non-cancellable channels simply don't have that parameter.
+ *
+ * @param <E> the event class this channel dispatches
+ * @param <H> the typed handler interface for this event
+ */
+public abstract class EventChannel<E extends GrimEvent<?>, H> {
+    private final Class<E> eventClass;
+    private final Class<H> handlerType;
+    private final Object writeLock = new Object();
+    private volatile Entry<H>[] entries;
+    private volatile int legacyCount;
+    private volatile @Nullable PluginResolver pluginResolver;
+
+    @SuppressWarnings("unchecked")
+    protected EventChannel(@NotNull Class<E> eventClass, @NotNull Class<H> handlerType) {
+        this.eventClass = eventClass;
+        this.handlerType = handlerType;
+        this.entries = (Entry<H>[]) new Entry[0];
+    }
+
+    /** Returns the event class this channel serves. */
+    public final @NotNull Class<E> eventClass() {
+        return eventClass;
+    }
+
+    /** Returns the typed handler interface for this channel. */
+    public final @NotNull Class<H> handlerType() {
+        return handlerType;
+    }
+
+    /**
+     * Snapshot of the sorted subscriber array. The returned array is never
+     * mutated after publication, so iteration is safe to use on the dispatch
+     * hot path without copying.
+     */
+    protected final @NotNull Entry<H>[] entries() {
+        return entries;
+    }
+
+    /**
+     * Returns {@code true} if any legacy subscriber is currently attached.
+     * Dispatch uses this to decide whether to touch its pooled-event
+     * {@code ThreadLocal} — skipping it entirely when the answer is {@code false}.
+     */
+    public final boolean hasLegacy() {
+        return legacyCount != 0;
+    }
+
+    /** Returns {@code true} if no subscribers of any kind are registered. */
+    public final boolean isEmpty() {
+        return entries.length == 0;
+    }
+
+    /**
+     * Registers a typed handler. Intended as the building block for the
+     * subclass's fluent {@code on…(…)} methods — external callers should use
+     * those, and plugin-lifecycle-bound subscribes should go through
+     * {@link EventBus#get(Class)} + the on-method so the bus can clean up
+     * automatically on plugin disable.
+     */
+    protected final void subscribe(@NotNull H handler, int priority, boolean ignoreCancelled,
+                                   @Nullable Object pluginContext, @Nullable Class<?> declaringClass) {
+        addEntry(new Entry<>(handler, null, null, priority, ignoreCancelled, pluginContext, declaringClass));
+    }
+
+    /**
+     * Internal: used by {@link AbstractEventChannel} to install a bridge
+     * entry into this concrete channel. Equivalent to the protected
+     * {@link #subscribe(Object, int, boolean, Object, Class)} with
+     * {@code declaringClass = null}, but publicly callable so the abstract
+     * channel (which lives in the same package) can reach cross-instance.
+     */
+    @ApiStatus.Internal
+    public final void subscribeTyped(@NotNull H handler, int priority, boolean ignoreCancelled,
+                                     @Nullable Object pluginContext) {
+        subscribe(handler, priority, ignoreCancelled, pluginContext, null);
+    }
+
+    /**
+     * Resolves a platform-specific plugin context ({@code JavaPlugin},
+     * Fabric {@code ModContainer}, …) into a {@link GrimPlugin}. Used by the
+     * deprecated {@code onX(Object ctx, Handler)} overloads on each
+     * subclass so plugin authors that don't have a {@code GrimPlugin} handy
+     * can still subscribe with lifecycle tracking.
+     *
+     * <p>Requires the bus to have installed a resolver via
+     * {@link #setPluginResolver(PluginResolver)}; channels used outside a
+     * bus (e.g. in unit tests) throw {@link IllegalStateException}.
+     */
+    @ApiStatus.Internal
+    protected final @NotNull GrimPlugin resolvePlugin(@NotNull Object pluginContext) {
+        if (pluginContext instanceof GrimPlugin) return (GrimPlugin) pluginContext;
+        PluginResolver r = this.pluginResolver;
+        if (r == null) {
+            throw new IllegalStateException("EventChannel " + eventClass.getSimpleName()
+                    + " has no plugin resolver installed; pass a GrimPlugin directly instead of a platform-specific context.");
+        }
+        return r.resolve(pluginContext);
+    }
+
+    /**
+     * Internal: installed by the bus on every registered channel so the
+     * deprecated Object-taking {@code onX(...)} overloads can route to a
+     * {@link GrimPlugin}.
+     */
+    @ApiStatus.Internal
+    public final void setPluginResolver(@Nullable PluginResolver resolver) {
+        this.pluginResolver = resolver;
+    }
+
+    /** Strategy for {@link #resolvePlugin(Object)}. Bus-provided. */
+    @FunctionalInterface
+    public interface PluginResolver {
+        @NotNull GrimPlugin resolve(@NotNull Object pluginContext);
+    }
+
+    /**
+     * Removes a previously registered typed handler. A no-op if the handler
+     * was never subscribed.
+     */
+    public void unsubscribe(@NotNull H handler) {
+        removeMatching(e -> e.handler == handler);
+    }
+
+    /**
+     * Internal: registers a legacy {@link GrimEventListener} on this channel's
+     * legacy slot. Invoked by the bus when a caller uses the deprecated
+     * class-keyed subscribe to bridge into the channel.
+     */
+    @ApiStatus.Internal
+    public final <GE extends GrimEvent<?>> void subscribeLegacy(
+            @NotNull GrimEventListener<GE> listener,
+            @NotNull Class<GE> legacyEventClass,
+            int priority, boolean ignoreCancelled,
+            @Nullable Object pluginContext, @Nullable Class<?> declaringClass) {
+        addEntry(new Entry<>(null, listener, legacyEventClass, priority, ignoreCancelled, pluginContext, declaringClass));
+    }
+
+    /** Internal: removes a specific legacy listener. */
+    @ApiStatus.Internal
+    public final void unsubscribeLegacy(@NotNull GrimEventListener<?> listener) {
+        removeMatching(e -> e.legacyListener == listener);
+    }
+
+    /** Internal: removes every subscriber bound to the given plugin context. */
+    @ApiStatus.Internal
+    public final void unsubscribeAllFromPlugin(@NotNull Object pluginContext) {
+        removeMatching(e -> pluginContext.equals(e.pluginContext));
+    }
+
+    /** Internal: removes every legacy subscriber declared by the given class. */
+    @ApiStatus.Internal
+    public final void unsubscribeLegacyFromClass(@NotNull Object pluginContext, @NotNull Class<?> declaringClass) {
+        removeMatching(e -> e.legacyListener != null
+                && pluginContext.equals(e.pluginContext)
+                && declaringClass.equals(e.declaringClass));
+    }
+
+    /**
+     * Internal: dispatches a legacy-style {@code GrimEvent} through this
+     * channel's subscribers. Both legacy-registered listeners and typed
+     * handlers are invoked — typed handlers by unpacking the event's fields
+     * via {@link #dispatchTypedFromLegacy(GrimEvent, Object, boolean)}.
+     *
+     * <p>Only reachable through {@link EventBus#post(GrimEvent)}. Internal
+     * Grim firings should call the subclass's typed {@code fire(...)}
+     * directly — it has the same dispatch semantics without the caller-side
+     * event instance allocation.
+     */
+    @ApiStatus.Internal
+    public final void dispatchLegacy(@NotNull E event) {
+        Entry<H>[] arr = entries;
+        if (arr.length == 0) return;
+
+        final boolean isCan = event instanceof Cancellable;
+        boolean cancelled = isCan && ((Cancellable) event).isCancelled();
+
+        for (Entry<H> e : arr) {
+            if (cancelled && !e.ignoreCancelled) continue;
+            try {
+                if (e.legacyListener != null) {
+                    if (isCan) ((Cancellable) event).setCancelled(cancelled);
+                    @SuppressWarnings("unchecked")
+                    GrimEventListener<E> listener = (GrimEventListener<E>) e.legacyListener;
+                    listener.handle(event);
+                    if (isCan) cancelled = ((Cancellable) event).isCancelled();
+                } else {
+                    cancelled = dispatchTypedFromLegacy(event, e.handler, cancelled);
+                }
+            } catch (Throwable t) {
+                t.printStackTrace();
+            }
+        }
+    }
+
+    /**
+     * Subclass hook: unpack the fields of a legacy event instance and invoke
+     * the typed {@code H} handler with positional parameters. Return the new
+     * cancelled state; non-cancellable channels ignore the parameter and
+     * return {@code false}.
+     *
+     * <p>Only invoked via {@link #dispatchLegacy(GrimEvent)}. The hot-path
+     * typed {@code fire(...)} never takes this route.
+     */
+    protected abstract boolean dispatchTypedFromLegacy(@NotNull E event, @NotNull H handler, boolean cancelled);
+
+    @SuppressWarnings("unchecked")
+    private void addEntry(Entry<H> entry) {
+        synchronized (writeLock) {
+            Entry<H>[] old = entries;
+            Entry<H>[] next = Arrays.copyOf(old, old.length + 1);
+            // Ascending priority: lower priority fires first, higher gets the final
+            // say on cancellation. Matches Bukkit / Paper EventPriority ordering.
+            int i = old.length;
+            while (i > 0 && old[i - 1].priority > entry.priority) {
+                next[i] = old[i - 1];
+                i--;
+            }
+            next[i] = entry;
+            entries = next;
+            if (entry.legacyListener != null) legacyCount++;
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    private void removeMatching(@NotNull java.util.function.Predicate<Entry<H>> filter) {
+        synchronized (writeLock) {
+            Entry<H>[] old = entries;
+            int keep = 0;
+            for (Entry<H> e : old) if (!filter.test(e)) keep++;
+            if (keep == old.length) return;
+            Entry<H>[] next = (Entry<H>[]) new Entry[keep];
+            int removedLegacy = 0;
+            int idx = 0;
+            for (Entry<H> e : old) {
+                if (filter.test(e)) {
+                    if (e.legacyListener != null) removedLegacy++;
+                } else {
+                    next[idx++] = e;
+                }
+            }
+            entries = next;
+            legacyCount -= removedLegacy;
+        }
+    }
+
+    /**
+     * One registered subscriber. Either {@code handler} is set (typed entry)
+     * or {@code legacyListener} + {@code legacyEventClass} are set (legacy
+     * entry) — never both. Entries are otherwise immutable after publication.
+     */
+    public static final class Entry<H> {
+        public final @Nullable H handler;
+        public final @Nullable GrimEventListener<? extends GrimEvent<?>> legacyListener;
+        public final @Nullable Class<? extends GrimEvent<?>> legacyEventClass;
+        public final int priority;
+        public final boolean ignoreCancelled;
+        public final @Nullable Object pluginContext;
+        public final @Nullable Class<?> declaringClass;
+
+        Entry(@Nullable H handler,
+              @Nullable GrimEventListener<? extends GrimEvent<?>> legacyListener,
+              @Nullable Class<? extends GrimEvent<?>> legacyEventClass,
+              int priority, boolean ignoreCancelled,
+              @Nullable Object pluginContext, @Nullable Class<?> declaringClass) {
+            this.handler = handler;
+            this.legacyListener = legacyListener;
+            this.legacyEventClass = legacyEventClass;
+            this.priority = priority;
+            this.ignoreCancelled = ignoreCancelled;
+            this.pluginContext = pluginContext;
+            this.declaringClass = declaringClass;
+        }
+
+        public boolean isLegacy() {
+            return legacyListener != null;
+        }
+
+        @SuppressWarnings("unchecked")
+        public <GE extends GrimEvent<?>> @NotNull GrimEventListener<GE> legacyListenerAs() {
+            return (GrimEventListener<GE>) legacyListener;
+        }
+    }
+}

--- a/src/main/java/ac/grim/grimac/api/event/GrimEvent.java
+++ b/src/main/java/ac/grim/grimac/api/event/GrimEvent.java
@@ -1,8 +1,26 @@
 package ac.grim.grimac.api.event;
 
+import ac.grim.grimac.api.plugin.GrimPlugin;
 import lombok.Getter;
+import org.jetbrains.annotations.ApiStatus;
+import org.jetbrains.annotations.NotNull;
 
-public abstract class GrimEvent {
+/**
+ * Base class for all Grim events.
+ *
+ * <p>The {@code CHANNEL} type parameter classifies each event with its
+ * {@link EventChannel} subclass so that {@link EventBus#get(Class)} can return
+ * the correct channel type without a cast at the call site.
+ *
+ * <p>External code should prefer subscribing via
+ * {@code bus.get(SomeEvent.class).onSomething(...)} — the legacy
+ * {@link EventBus#post(GrimEvent)} / class-keyed {@code subscribe} methods
+ * remain for source compatibility with pre-1.3 callers and internally route
+ * through the same {@code EventChannel}.
+ *
+ * @param <CHANNEL> the {@link EventChannel} subclass that dispatches this event
+ */
+public abstract class GrimEvent<CHANNEL extends EventChannel<?, ?>> {
     private @Getter boolean cancelled = false;
     private final boolean async;
 
@@ -27,5 +45,77 @@ public abstract class GrimEvent {
 
     public String getEventName() {
         return getClass().getSimpleName();
+    }
+
+    /**
+     * Clears transient event state so a pooled instance can be reused for a
+     * fresh dispatch. Subclasses holding additional mutable fields should
+     * override and call {@code super.resetForReuse()} first.
+     *
+     * <p>Invoked by channel dispatch on a per-thread pooled legacy event
+     * before it is re-populated. Not intended for direct caller use.
+     */
+    @ApiStatus.Internal
+    protected void resetForReuse() {
+        this.cancelled = false;
+    }
+
+    /**
+     * Root-level event handler. Fires for every concrete event channel —
+     * intended for debug / metrics consumers that want to count, categorise,
+     * or observe cancellation state across all events without caring about
+     * specific fields.
+     *
+     * <p>For cancellable events {@code currentlyCancelled} is the threaded
+     * state at the point this handler runs; for non-cancellable events it's
+     * always {@code false}. Return type is {@code void} because root-level
+     * observers shouldn't affect cancellation — bridges thread the cancelled
+     * state through priority-ordered dispatch unchanged.
+     *
+     * <p>Plugins that need positional fields for a specific event family
+     * should subscribe at a narrower level — {@code GrimCheckEvent.Handler}
+     * for cancellable check events, or the concrete event's own
+     * {@code on…(...)} for full field access.
+     */
+    @FunctionalInterface
+    public interface Handler {
+        void onAnyEvent(@NotNull Class<? extends GrimEvent<?>> eventClass, boolean currentlyCancelled);
+    }
+
+    public static final class Channel extends AbstractEventChannel<GrimEvent<?>, Handler> {
+        @SuppressWarnings({"unchecked", "rawtypes"})
+        public Channel() {
+            super((Class<GrimEvent<?>>) (Class) GrimEvent.class, Handler.class);
+        }
+
+        public void onAnyEvent(@NotNull GrimPlugin plugin, @NotNull Handler handler) {
+            subscribeAbstract(handler, 0, false, plugin);
+        }
+
+        public void onAnyEvent(@NotNull GrimPlugin plugin, @NotNull Handler handler, int priority) {
+            subscribeAbstract(handler, priority, false, plugin);
+        }
+
+        public void onAnyEvent(@NotNull GrimPlugin plugin, @NotNull Handler handler, int priority, boolean ignoreCancelled) {
+            subscribeAbstract(handler, priority, ignoreCancelled, plugin);
+        }
+
+        /** @deprecated resolve your context once at plugin enable — {@code api.getGrimPlugin(this)} — and call the {@link GrimPlugin}-taking overload. */
+        @Deprecated
+        public void onAnyEvent(@NotNull Object pluginContext, @NotNull Handler handler) {
+            subscribeAbstractResolving(pluginContext, handler, 0, false);
+        }
+
+        /** @deprecated see {@link #onAnyEvent(Object, Handler)}. */
+        @Deprecated
+        public void onAnyEvent(@NotNull Object pluginContext, @NotNull Handler handler, int priority) {
+            subscribeAbstractResolving(pluginContext, handler, priority, false);
+        }
+
+        /** @deprecated see {@link #onAnyEvent(Object, Handler)}. */
+        @Deprecated
+        public void onAnyEvent(@NotNull Object pluginContext, @NotNull Handler handler, int priority, boolean ignoreCancelled) {
+            subscribeAbstractResolving(pluginContext, handler, priority, ignoreCancelled);
+        }
     }
 }

--- a/src/main/java/ac/grim/grimac/api/event/GrimEventListener.java
+++ b/src/main/java/ac/grim/grimac/api/event/GrimEventListener.java
@@ -1,6 +1,6 @@
 package ac.grim.grimac.api.event;
 
 @FunctionalInterface
-public interface GrimEventListener<T extends GrimEvent> {
+public interface GrimEventListener<T extends GrimEvent<?>> {
     void handle(T event) throws Exception;
 }

--- a/src/main/java/ac/grim/grimac/api/event/events/CommandExecuteEvent.java
+++ b/src/main/java/ac/grim/grimac/api/event/events/CommandExecuteEvent.java
@@ -2,16 +2,140 @@ package ac.grim.grimac.api.event.events;
 
 import ac.grim.grimac.api.AbstractCheck;
 import ac.grim.grimac.api.GrimUser;
+import ac.grim.grimac.api.event.EventChannel;
+import ac.grim.grimac.api.plugin.GrimPlugin;
+import org.jetbrains.annotations.ApiStatus;
+import org.jetbrains.annotations.NotNull;
 
-public class CommandExecuteEvent extends GrimVerboseCheckEvent {
-    private final String command;
+public class CommandExecuteEvent extends GrimVerboseCheckEvent<CommandExecuteEvent.Channel> {
+    private String command;
+
+    /** Pool constructor — fields populated via {@link #init}. */
+    public CommandExecuteEvent() {
+        super();
+    }
 
     public CommandExecuteEvent(GrimUser player, AbstractCheck check, String verbose, String command) {
         super(player, check, verbose);
         this.command = command;
     }
 
+    @ApiStatus.Internal
+    public void init(GrimUser user, AbstractCheck check, String verbose, String command) {
+        super.init(user, check, verbose);
+        this.command = command;
+    }
+
     public String getCommand() {
         return command;
+    }
+
+    /**
+     * Typed command-execute handler. Returns the new cancelled state — see
+     * {@link FlagEvent.Handler} for the cancellation contract.
+     */
+    @FunctionalInterface
+    public interface Handler {
+        boolean onCommandExecute(@NotNull GrimUser user, @NotNull AbstractCheck check,
+                                 @NotNull String verbose, @NotNull String command,
+                                 boolean currentlyCancelled);
+    }
+
+    public static final class Channel extends EventChannel<CommandExecuteEvent, Handler> {
+        private final ThreadLocal<CommandExecuteEvent> legacyPool = ThreadLocal.withInitial(CommandExecuteEvent::new);
+
+        public Channel() {
+            super(CommandExecuteEvent.class, Handler.class);
+        }
+
+        public void onCommandExecute(@NotNull GrimPlugin plugin, @NotNull Handler handler) {
+            subscribe(handler, 0, false, plugin, null);
+        }
+
+        public void onCommandExecute(@NotNull GrimPlugin plugin, @NotNull Handler handler, int priority) {
+            subscribe(handler, priority, false, plugin, null);
+        }
+
+        public void onCommandExecute(@NotNull GrimPlugin plugin, @NotNull Handler handler, int priority, boolean ignoreCancelled) {
+            subscribe(handler, priority, ignoreCancelled, plugin, null);
+        }
+
+        /** @deprecated resolve your context once at plugin enable — {@code api.getGrimPlugin(this)} — and call the {@link GrimPlugin}-taking overload. */
+        @Deprecated
+        public void onCommandExecute(@NotNull Object pluginContext, @NotNull Handler handler) {
+            onCommandExecute(resolvePlugin(pluginContext), handler);
+        }
+
+        /** @deprecated see {@link #onCommandExecute(Object, Handler)}. */
+        @Deprecated
+        public void onCommandExecute(@NotNull Object pluginContext, @NotNull Handler handler, int priority) {
+            onCommandExecute(resolvePlugin(pluginContext), handler, priority);
+        }
+
+        /** @deprecated see {@link #onCommandExecute(Object, Handler)}. */
+        @Deprecated
+        public void onCommandExecute(@NotNull Object pluginContext, @NotNull Handler handler, int priority, boolean ignoreCancelled) {
+            onCommandExecute(resolvePlugin(pluginContext), handler, priority, ignoreCancelled);
+        }
+
+        public boolean fire(@NotNull GrimUser user, @NotNull AbstractCheck check,
+                            @NotNull String verbose, @NotNull String command) {
+            Entry<Handler>[] entries = entries();
+            if (entries.length == 0) return false;
+
+            boolean cancelled = false;
+            if (!hasLegacy()) {
+                for (Entry<Handler> e : entries) {
+                    if (cancelled && !e.ignoreCancelled) continue;
+                    try {
+                        cancelled = e.handler.onCommandExecute(user, check, verbose, command, cancelled);
+                    } catch (Throwable t) {
+                        t.printStackTrace();
+                    }
+                }
+                return cancelled;
+            }
+
+            CommandExecuteEvent pooled = legacyPool.get();
+            pooled.init(user, check, verbose, command);
+            for (Entry<Handler> e : entries) {
+                if (cancelled && !e.ignoreCancelled) continue;
+                try {
+                    if (e.legacyListener != null) {
+                        pooled.setCancelled(cancelled);
+                        e.<CommandExecuteEvent>legacyListenerAs().handle(pooled);
+                        cancelled = pooled.isCancelled();
+                    } else {
+                        cancelled = e.handler.onCommandExecute(user, check, verbose, command, cancelled);
+                    }
+                } catch (Throwable t) {
+                    t.printStackTrace();
+                }
+            }
+            return cancelled;
+        }
+
+        @Override
+        protected boolean dispatchTypedFromLegacy(@NotNull CommandExecuteEvent event, @NotNull Handler handler, boolean cancelled) {
+            return handler.onCommandExecute(event.getUser(), event.getCheck(), event.getVerbose(), event.getCommand(), cancelled);
+        }
+
+        @ApiStatus.Internal
+        public static @NotNull Handler bridgeFromCheck(@NotNull GrimCheckEvent.Handler abstractHandler) {
+            return (user, check, verbose, command, cancelled) -> abstractHandler.onCheck(user, check, cancelled);
+        }
+
+        @ApiStatus.Internal
+        public static @NotNull Handler bridgeFromVerboseCheck(@NotNull GrimVerboseCheckEvent.Handler abstractHandler) {
+            return (user, check, verbose, command, cancelled) -> abstractHandler.onVerboseCheck(user, check, verbose, cancelled);
+        }
+
+        @ApiStatus.Internal
+        public static @NotNull Handler bridgeFromAny(@NotNull ac.grim.grimac.api.event.GrimEvent.Handler abstractHandler) {
+            return (user, check, verbose, command, cancelled) -> {
+                abstractHandler.onAnyEvent(CommandExecuteEvent.class, cancelled);
+                return cancelled;
+            };
+        }
     }
 }

--- a/src/main/java/ac/grim/grimac/api/event/events/CompletePredictionEvent.java
+++ b/src/main/java/ac/grim/grimac/api/event/events/CompletePredictionEvent.java
@@ -2,16 +2,134 @@ package ac.grim.grimac.api.event.events;
 
 import ac.grim.grimac.api.AbstractCheck;
 import ac.grim.grimac.api.GrimUser;
+import ac.grim.grimac.api.event.EventChannel;
+import ac.grim.grimac.api.plugin.GrimPlugin;
+import org.jetbrains.annotations.ApiStatus;
+import org.jetbrains.annotations.NotNull;
 
-public class CompletePredictionEvent extends GrimCheckEvent {
-    private final double offset;
+public class CompletePredictionEvent extends GrimCheckEvent<CompletePredictionEvent.Channel> {
+    private double offset;
+
+    /** Pool constructor — fields populated via {@link #init}. */
+    public CompletePredictionEvent() {
+        super();
+    }
 
     public CompletePredictionEvent(GrimUser player, AbstractCheck check, double offset) {
         super(player, check);
         this.offset = offset;
     }
 
+    @ApiStatus.Internal
+    public void init(GrimUser user, AbstractCheck check, double offset) {
+        super.init(user, check);
+        this.offset = offset;
+    }
+
     public double getOffset() {
         return offset;
+    }
+
+    /**
+     * Typed prediction-complete handler. Returns the new cancelled state — see
+     * {@link FlagEvent.Handler} for the cancellation contract.
+     */
+    @FunctionalInterface
+    public interface Handler {
+        boolean onCompletePrediction(@NotNull GrimUser user, @NotNull AbstractCheck check,
+                                     double offset, boolean currentlyCancelled);
+    }
+
+    public static final class Channel extends EventChannel<CompletePredictionEvent, Handler> {
+        private final ThreadLocal<CompletePredictionEvent> legacyPool =
+                ThreadLocal.withInitial(CompletePredictionEvent::new);
+
+        public Channel() {
+            super(CompletePredictionEvent.class, Handler.class);
+        }
+
+        public void onCompletePrediction(@NotNull GrimPlugin plugin, @NotNull Handler handler) {
+            subscribe(handler, 0, false, plugin, null);
+        }
+
+        public void onCompletePrediction(@NotNull GrimPlugin plugin, @NotNull Handler handler, int priority) {
+            subscribe(handler, priority, false, plugin, null);
+        }
+
+        public void onCompletePrediction(@NotNull GrimPlugin plugin, @NotNull Handler handler, int priority, boolean ignoreCancelled) {
+            subscribe(handler, priority, ignoreCancelled, plugin, null);
+        }
+
+        /** @deprecated resolve your context once at plugin enable — {@code api.getGrimPlugin(this)} — and call the {@link GrimPlugin}-taking overload. */
+        @Deprecated
+        public void onCompletePrediction(@NotNull Object pluginContext, @NotNull Handler handler) {
+            onCompletePrediction(resolvePlugin(pluginContext), handler);
+        }
+
+        /** @deprecated see {@link #onCompletePrediction(Object, Handler)}. */
+        @Deprecated
+        public void onCompletePrediction(@NotNull Object pluginContext, @NotNull Handler handler, int priority) {
+            onCompletePrediction(resolvePlugin(pluginContext), handler, priority);
+        }
+
+        /** @deprecated see {@link #onCompletePrediction(Object, Handler)}. */
+        @Deprecated
+        public void onCompletePrediction(@NotNull Object pluginContext, @NotNull Handler handler, int priority, boolean ignoreCancelled) {
+            onCompletePrediction(resolvePlugin(pluginContext), handler, priority, ignoreCancelled);
+        }
+
+        public boolean fire(@NotNull GrimUser user, @NotNull AbstractCheck check, double offset) {
+            Entry<Handler>[] entries = entries();
+            if (entries.length == 0) return false;
+
+            boolean cancelled = false;
+            if (!hasLegacy()) {
+                for (Entry<Handler> e : entries) {
+                    if (cancelled && !e.ignoreCancelled) continue;
+                    try {
+                        cancelled = e.handler.onCompletePrediction(user, check, offset, cancelled);
+                    } catch (Throwable t) {
+                        t.printStackTrace();
+                    }
+                }
+                return cancelled;
+            }
+
+            CompletePredictionEvent pooled = legacyPool.get();
+            pooled.init(user, check, offset);
+            for (Entry<Handler> e : entries) {
+                if (cancelled && !e.ignoreCancelled) continue;
+                try {
+                    if (e.legacyListener != null) {
+                        pooled.setCancelled(cancelled);
+                        e.<CompletePredictionEvent>legacyListenerAs().handle(pooled);
+                        cancelled = pooled.isCancelled();
+                    } else {
+                        cancelled = e.handler.onCompletePrediction(user, check, offset, cancelled);
+                    }
+                } catch (Throwable t) {
+                    t.printStackTrace();
+                }
+            }
+            return cancelled;
+        }
+
+        @Override
+        protected boolean dispatchTypedFromLegacy(@NotNull CompletePredictionEvent event, @NotNull Handler handler, boolean cancelled) {
+            return handler.onCompletePrediction(event.getUser(), event.getCheck(), event.getOffset(), cancelled);
+        }
+
+        @ApiStatus.Internal
+        public static @NotNull Handler bridgeFromCheck(@NotNull GrimCheckEvent.Handler abstractHandler) {
+            return (user, check, offset, cancelled) -> abstractHandler.onCheck(user, check, cancelled);
+        }
+
+        @ApiStatus.Internal
+        public static @NotNull Handler bridgeFromAny(@NotNull ac.grim.grimac.api.event.GrimEvent.Handler abstractHandler) {
+            return (user, check, offset, cancelled) -> {
+                abstractHandler.onAnyEvent(CompletePredictionEvent.class, cancelled);
+                return cancelled;
+            };
+        }
     }
 }

--- a/src/main/java/ac/grim/grimac/api/event/events/FlagEvent.java
+++ b/src/main/java/ac/grim/grimac/api/event/events/FlagEvent.java
@@ -2,10 +2,139 @@ package ac.grim.grimac.api.event.events;
 
 import ac.grim.grimac.api.AbstractCheck;
 import ac.grim.grimac.api.GrimUser;
+import ac.grim.grimac.api.event.EventChannel;
+import ac.grim.grimac.api.plugin.GrimPlugin;
+import org.jetbrains.annotations.ApiStatus;
+import org.jetbrains.annotations.NotNull;
 
-public class FlagEvent extends GrimVerboseCheckEvent {
+public class FlagEvent extends GrimVerboseCheckEvent<FlagEvent.Channel> {
+
+    /** Pool constructor — fields populated via {@link #init}. */
+    public FlagEvent() {
+        super();
+    }
 
     public FlagEvent(GrimUser user, AbstractCheck check, String verbose) {
         super(user, check, verbose);
+    }
+
+    @ApiStatus.Internal
+    @Override
+    public void init(GrimUser user, AbstractCheck check, String verbose) {
+        super.init(user, check, verbose);
+    }
+
+    /**
+     * Typed flag handler. Returns the new cancelled state — returning
+     * {@code true} cancels, {@code false} leaves uncancelled. The last
+     * parameter carries the cancelled state threaded through priority-ordered
+     * dispatch; a handler registered with {@code ignoreCancelled = true}
+     * still runs when a higher-priority handler already cancelled the event.
+     */
+    @FunctionalInterface
+    public interface Handler {
+        boolean onFlag(@NotNull GrimUser user, @NotNull AbstractCheck check,
+                       @NotNull String verbose, boolean currentlyCancelled);
+    }
+
+    public static final class Channel extends EventChannel<FlagEvent, Handler> {
+        private final ThreadLocal<FlagEvent> legacyPool = ThreadLocal.withInitial(FlagEvent::new);
+
+        public Channel() {
+            super(FlagEvent.class, Handler.class);
+        }
+
+        public void onFlag(@NotNull GrimPlugin plugin, @NotNull Handler handler) {
+            subscribe(handler, 0, false, plugin, null);
+        }
+
+        public void onFlag(@NotNull GrimPlugin plugin, @NotNull Handler handler, int priority) {
+            subscribe(handler, priority, false, plugin, null);
+        }
+
+        public void onFlag(@NotNull GrimPlugin plugin, @NotNull Handler handler, int priority, boolean ignoreCancelled) {
+            subscribe(handler, priority, ignoreCancelled, plugin, null);
+        }
+
+        /** @deprecated resolve your context once at plugin enable — {@code api.getGrimPlugin(this)} — and call the {@link GrimPlugin}-taking overload. */
+        @Deprecated
+        public void onFlag(@NotNull Object pluginContext, @NotNull Handler handler) {
+            onFlag(resolvePlugin(pluginContext), handler);
+        }
+
+        /** @deprecated see {@link #onFlag(Object, Handler)}. */
+        @Deprecated
+        public void onFlag(@NotNull Object pluginContext, @NotNull Handler handler, int priority) {
+            onFlag(resolvePlugin(pluginContext), handler, priority);
+        }
+
+        /** @deprecated see {@link #onFlag(Object, Handler)}. */
+        @Deprecated
+        public void onFlag(@NotNull Object pluginContext, @NotNull Handler handler, int priority, boolean ignoreCancelled) {
+            onFlag(resolvePlugin(pluginContext), handler, priority, ignoreCancelled);
+        }
+
+        /** Dispatches the event. Returns the final cancelled state after all handlers run. */
+        public boolean fire(@NotNull GrimUser user, @NotNull AbstractCheck check, @NotNull String verbose) {
+            Entry<Handler>[] entries = entries();
+            if (entries.length == 0) return false;
+
+            boolean cancelled = false;
+            if (!hasLegacy()) {
+                for (Entry<Handler> e : entries) {
+                    if (cancelled && !e.ignoreCancelled) continue;
+                    try {
+                        cancelled = e.handler.onFlag(user, check, verbose, cancelled);
+                    } catch (Throwable t) {
+                        t.printStackTrace();
+                    }
+                }
+                return cancelled;
+            }
+
+            FlagEvent pooled = legacyPool.get();
+            pooled.init(user, check, verbose);
+            for (Entry<Handler> e : entries) {
+                if (cancelled && !e.ignoreCancelled) continue;
+                try {
+                    if (e.legacyListener != null) {
+                        pooled.setCancelled(cancelled);
+                        e.<FlagEvent>legacyListenerAs().handle(pooled);
+                        cancelled = pooled.isCancelled();
+                    } else {
+                        cancelled = e.handler.onFlag(user, check, verbose, cancelled);
+                    }
+                } catch (Throwable t) {
+                    t.printStackTrace();
+                }
+            }
+            return cancelled;
+        }
+
+        @Override
+        protected boolean dispatchTypedFromLegacy(@NotNull FlagEvent event, @NotNull Handler handler, boolean cancelled) {
+            return handler.onFlag(event.getUser(), event.getCheck(), event.getVerbose(), cancelled);
+        }
+
+        /** Bridge from {@link GrimCheckEvent.Handler} — used by the abstract channel when a check-level subscriber registers. */
+        @ApiStatus.Internal
+        public static @NotNull Handler bridgeFromCheck(@NotNull GrimCheckEvent.Handler abstractHandler) {
+            return (user, check, verbose, cancelled) -> abstractHandler.onCheck(user, check, cancelled);
+        }
+
+        /** Bridge from {@link GrimVerboseCheckEvent.Handler}. */
+        @ApiStatus.Internal
+        public static @NotNull Handler bridgeFromVerboseCheck(@NotNull GrimVerboseCheckEvent.Handler abstractHandler) {
+            return (user, check, verbose, cancelled) -> abstractHandler.onVerboseCheck(user, check, verbose, cancelled);
+        }
+
+        /** Bridge from root-level {@link ac.grim.grimac.api.event.GrimEvent.Handler} — observational only, cancelled is passed through unchanged. */
+        @ApiStatus.Internal
+        public static @NotNull Handler bridgeFromAny(@NotNull ac.grim.grimac.api.event.GrimEvent.Handler abstractHandler) {
+            return (user, check, verbose, cancelled) -> {
+                abstractHandler.onAnyEvent(FlagEvent.class, cancelled);
+                return cancelled;
+            };
+        }
     }
 }

--- a/src/main/java/ac/grim/grimac/api/event/events/GrimCheckEvent.java
+++ b/src/main/java/ac/grim/grimac/api/event/events/GrimCheckEvent.java
@@ -2,20 +2,39 @@ package ac.grim.grimac.api.event.events;
 
 import ac.grim.grimac.api.AbstractCheck;
 import ac.grim.grimac.api.GrimUser;
+import ac.grim.grimac.api.event.AbstractEventChannel;
 import ac.grim.grimac.api.event.Cancellable;
+import ac.grim.grimac.api.event.EventChannel;
 import ac.grim.grimac.api.event.GrimEvent;
+import ac.grim.grimac.api.plugin.GrimPlugin;
 import lombok.Getter;
+import org.jetbrains.annotations.ApiStatus;
+import org.jetbrains.annotations.NotNull;
 
-public abstract class GrimCheckEvent extends GrimEvent implements GrimUserEvent, Cancellable {
-    private final GrimUser user;
+public abstract class GrimCheckEvent<CHANNEL extends EventChannel<?, ?>>
+        extends GrimEvent<CHANNEL> implements GrimUserEvent, Cancellable {
+    private GrimUser user;
     @Getter
-    protected final AbstractCheck check;
+    protected AbstractCheck check;
     private boolean cancelled;
+
+    /** Pool constructor — fields populated via {@link #init(GrimUser, AbstractCheck)}. */
+    protected GrimCheckEvent() {
+        super(true); // Async
+    }
 
     public GrimCheckEvent(GrimUser user, AbstractCheck check) {
         super(true); // Async
         this.user = user;
         this.check = check;
+    }
+
+    @ApiStatus.Internal
+    protected void init(GrimUser user, AbstractCheck check) {
+        resetForReuse();
+        this.user = user;
+        this.check = check;
+        this.cancelled = false;
     }
 
     @Override
@@ -44,5 +63,58 @@ public abstract class GrimCheckEvent extends GrimEvent implements GrimUserEvent,
 
     public boolean isSetback() {
         return check.getViolations() > check.getSetbackVL();
+    }
+
+    /**
+     * Abstract-level check handler. Fires for every concrete
+     * {@code GrimCheckEvent} subtype (FlagEvent, CompletePredictionEvent,
+     * CommandExecuteEvent, and any addon subtypes that opt into bridging).
+     *
+     * <p>Returns the new cancelled state — the value is threaded back into
+     * the priority-ordered dispatch loop of whichever concrete subtype
+     * fired, so a high-priority abstract subscriber can cancel and
+     * lower-priority direct subscribers to the concrete event see the
+     * cancellation just like any other priority-ordered handler.
+     */
+    @FunctionalInterface
+    public interface Handler {
+        boolean onCheck(@NotNull GrimUser user, @NotNull AbstractCheck check, boolean currentlyCancelled);
+    }
+
+    public static final class Channel extends AbstractEventChannel<GrimCheckEvent<?>, Handler> {
+        @SuppressWarnings({"unchecked", "rawtypes"})
+        public Channel() {
+            super((Class<GrimCheckEvent<?>>) (Class) GrimCheckEvent.class, Handler.class);
+        }
+
+        public void onCheck(@NotNull GrimPlugin plugin, @NotNull Handler handler) {
+            subscribeAbstract(handler, 0, false, plugin);
+        }
+
+        public void onCheck(@NotNull GrimPlugin plugin, @NotNull Handler handler, int priority) {
+            subscribeAbstract(handler, priority, false, plugin);
+        }
+
+        public void onCheck(@NotNull GrimPlugin plugin, @NotNull Handler handler, int priority, boolean ignoreCancelled) {
+            subscribeAbstract(handler, priority, ignoreCancelled, plugin);
+        }
+
+        /** @deprecated resolve your context once at plugin enable — {@code api.getGrimPlugin(this)} — and call the {@link GrimPlugin}-taking overload. */
+        @Deprecated
+        public void onCheck(@NotNull Object pluginContext, @NotNull Handler handler) {
+            subscribeAbstractResolving(pluginContext, handler, 0, false);
+        }
+
+        /** @deprecated see {@link #onCheck(Object, Handler)}. */
+        @Deprecated
+        public void onCheck(@NotNull Object pluginContext, @NotNull Handler handler, int priority) {
+            subscribeAbstractResolving(pluginContext, handler, priority, false);
+        }
+
+        /** @deprecated see {@link #onCheck(Object, Handler)}. */
+        @Deprecated
+        public void onCheck(@NotNull Object pluginContext, @NotNull Handler handler, int priority, boolean ignoreCancelled) {
+            subscribeAbstractResolving(pluginContext, handler, priority, ignoreCancelled);
+        }
     }
 }

--- a/src/main/java/ac/grim/grimac/api/event/events/GrimJoinEvent.java
+++ b/src/main/java/ac/grim/grimac/api/event/events/GrimJoinEvent.java
@@ -1,18 +1,105 @@
 package ac.grim.grimac.api.event.events;
 
 import ac.grim.grimac.api.GrimUser;
+import ac.grim.grimac.api.event.EventChannel;
 import ac.grim.grimac.api.event.GrimEvent;
+import ac.grim.grimac.api.plugin.GrimPlugin;
+import org.jetbrains.annotations.ApiStatus;
+import org.jetbrains.annotations.NotNull;
 
-public class GrimJoinEvent extends GrimEvent implements GrimUserEvent {
-    private final GrimUser user;
+public class GrimJoinEvent extends GrimEvent<GrimJoinEvent.Channel> implements GrimUserEvent {
+    private GrimUser user;
+
+    /** Pool constructor — fields populated via {@link #init}. */
+    public GrimJoinEvent() {
+        super(true); // Async
+    }
 
     public GrimJoinEvent(GrimUser user) {
         super(true); // Async
         this.user = user;
     }
 
+    @ApiStatus.Internal
+    public void init(GrimUser user) {
+        resetForReuse();
+        this.user = user;
+    }
+
     @Override
     public GrimUser getUser() {
         return user;
+    }
+
+    @FunctionalInterface
+    public interface Handler {
+        void onJoin(@NotNull GrimUser user);
+    }
+
+    public static final class Channel extends EventChannel<GrimJoinEvent, Handler> {
+        private final ThreadLocal<GrimJoinEvent> legacyPool = ThreadLocal.withInitial(GrimJoinEvent::new);
+
+        public Channel() {
+            super(GrimJoinEvent.class, Handler.class);
+        }
+
+        public void onJoin(@NotNull GrimPlugin plugin, @NotNull Handler handler) {
+            subscribe(handler, 0, false, plugin, null);
+        }
+
+        public void onJoin(@NotNull GrimPlugin plugin, @NotNull Handler handler, int priority) {
+            subscribe(handler, priority, false, plugin, null);
+        }
+
+        /** @deprecated resolve your context once at plugin enable — {@code api.getGrimPlugin(this)} — and call the {@link GrimPlugin}-taking overload. */
+        @Deprecated
+        public void onJoin(@NotNull Object pluginContext, @NotNull Handler handler) {
+            onJoin(resolvePlugin(pluginContext), handler);
+        }
+
+        /** @deprecated see {@link #onJoin(Object, Handler)}. */
+        @Deprecated
+        public void onJoin(@NotNull Object pluginContext, @NotNull Handler handler, int priority) {
+            onJoin(resolvePlugin(pluginContext), handler, priority);
+        }
+
+        public void fire(@NotNull GrimUser user) {
+            Entry<Handler>[] entries = entries();
+            if (entries.length == 0) return;
+            if (!hasLegacy()) {
+                for (Entry<Handler> e : entries) {
+                    try {
+                        e.handler.onJoin(user);
+                    } catch (Throwable t) {
+                        t.printStackTrace();
+                    }
+                }
+                return;
+            }
+            GrimJoinEvent pooled = legacyPool.get();
+            pooled.init(user);
+            for (Entry<Handler> e : entries) {
+                try {
+                    if (e.legacyListener != null) {
+                        e.<GrimJoinEvent>legacyListenerAs().handle(pooled);
+                    } else {
+                        e.handler.onJoin(user);
+                    }
+                } catch (Throwable t) {
+                    t.printStackTrace();
+                }
+            }
+        }
+
+        @Override
+        protected boolean dispatchTypedFromLegacy(@NotNull GrimJoinEvent event, @NotNull Handler handler, boolean cancelled) {
+            handler.onJoin(event.getUser());
+            return false;
+        }
+
+        @ApiStatus.Internal
+        public static @NotNull Handler bridgeFromAny(@NotNull ac.grim.grimac.api.event.GrimEvent.Handler abstractHandler) {
+            return user -> abstractHandler.onAnyEvent(GrimJoinEvent.class, false);
+        }
     }
 }

--- a/src/main/java/ac/grim/grimac/api/event/events/GrimQuitEvent.java
+++ b/src/main/java/ac/grim/grimac/api/event/events/GrimQuitEvent.java
@@ -1,18 +1,105 @@
 package ac.grim.grimac.api.event.events;
 
 import ac.grim.grimac.api.GrimUser;
+import ac.grim.grimac.api.event.EventChannel;
 import ac.grim.grimac.api.event.GrimEvent;
+import ac.grim.grimac.api.plugin.GrimPlugin;
+import org.jetbrains.annotations.ApiStatus;
+import org.jetbrains.annotations.NotNull;
 
-public class GrimQuitEvent extends GrimEvent implements GrimUserEvent {
-    private final GrimUser user;
+public class GrimQuitEvent extends GrimEvent<GrimQuitEvent.Channel> implements GrimUserEvent {
+    private GrimUser user;
+
+    /** Pool constructor — fields populated via {@link #init}. */
+    public GrimQuitEvent() {
+        super(true); // Async
+    }
 
     public GrimQuitEvent(GrimUser user) {
         super(true); // Async
         this.user = user;
     }
 
+    @ApiStatus.Internal
+    public void init(GrimUser user) {
+        resetForReuse();
+        this.user = user;
+    }
+
     @Override
     public GrimUser getUser() {
         return user;
+    }
+
+    @FunctionalInterface
+    public interface Handler {
+        void onQuit(@NotNull GrimUser user);
+    }
+
+    public static final class Channel extends EventChannel<GrimQuitEvent, Handler> {
+        private final ThreadLocal<GrimQuitEvent> legacyPool = ThreadLocal.withInitial(GrimQuitEvent::new);
+
+        public Channel() {
+            super(GrimQuitEvent.class, Handler.class);
+        }
+
+        public void onQuit(@NotNull GrimPlugin plugin, @NotNull Handler handler) {
+            subscribe(handler, 0, false, plugin, null);
+        }
+
+        public void onQuit(@NotNull GrimPlugin plugin, @NotNull Handler handler, int priority) {
+            subscribe(handler, priority, false, plugin, null);
+        }
+
+        /** @deprecated resolve your context once at plugin enable — {@code api.getGrimPlugin(this)} — and call the {@link GrimPlugin}-taking overload. */
+        @Deprecated
+        public void onQuit(@NotNull Object pluginContext, @NotNull Handler handler) {
+            onQuit(resolvePlugin(pluginContext), handler);
+        }
+
+        /** @deprecated see {@link #onQuit(Object, Handler)}. */
+        @Deprecated
+        public void onQuit(@NotNull Object pluginContext, @NotNull Handler handler, int priority) {
+            onQuit(resolvePlugin(pluginContext), handler, priority);
+        }
+
+        public void fire(@NotNull GrimUser user) {
+            Entry<Handler>[] entries = entries();
+            if (entries.length == 0) return;
+            if (!hasLegacy()) {
+                for (Entry<Handler> e : entries) {
+                    try {
+                        e.handler.onQuit(user);
+                    } catch (Throwable t) {
+                        t.printStackTrace();
+                    }
+                }
+                return;
+            }
+            GrimQuitEvent pooled = legacyPool.get();
+            pooled.init(user);
+            for (Entry<Handler> e : entries) {
+                try {
+                    if (e.legacyListener != null) {
+                        e.<GrimQuitEvent>legacyListenerAs().handle(pooled);
+                    } else {
+                        e.handler.onQuit(user);
+                    }
+                } catch (Throwable t) {
+                    t.printStackTrace();
+                }
+            }
+        }
+
+        @Override
+        protected boolean dispatchTypedFromLegacy(@NotNull GrimQuitEvent event, @NotNull Handler handler, boolean cancelled) {
+            handler.onQuit(event.getUser());
+            return false;
+        }
+
+        @ApiStatus.Internal
+        public static @NotNull Handler bridgeFromAny(@NotNull ac.grim.grimac.api.event.GrimEvent.Handler abstractHandler) {
+            return user -> abstractHandler.onAnyEvent(GrimQuitEvent.class, false);
+        }
     }
 }

--- a/src/main/java/ac/grim/grimac/api/event/events/GrimReloadEvent.java
+++ b/src/main/java/ac/grim/grimac/api/event/events/GrimReloadEvent.java
@@ -1,16 +1,103 @@
 package ac.grim.grimac.api.event.events;
 
+import ac.grim.grimac.api.event.EventChannel;
 import ac.grim.grimac.api.event.GrimEvent;
+import ac.grim.grimac.api.plugin.GrimPlugin;
+import org.jetbrains.annotations.ApiStatus;
+import org.jetbrains.annotations.NotNull;
 
-public class GrimReloadEvent extends GrimEvent {
-    private final boolean success;
+public class GrimReloadEvent extends GrimEvent<GrimReloadEvent.Channel> {
+    private boolean success;
+
+    /** Pool constructor — fields populated via {@link #init}. */
+    public GrimReloadEvent() {
+        super(true); // Async
+    }
 
     public GrimReloadEvent(boolean success) {
         super(true); // Async
         this.success = success;
     }
 
+    @ApiStatus.Internal
+    public void init(boolean success) {
+        resetForReuse();
+        this.success = success;
+    }
+
     public boolean isSuccess() {
         return success;
+    }
+
+    @FunctionalInterface
+    public interface Handler {
+        void onReload(boolean success);
+    }
+
+    public static final class Channel extends EventChannel<GrimReloadEvent, Handler> {
+        private final ThreadLocal<GrimReloadEvent> legacyPool = ThreadLocal.withInitial(GrimReloadEvent::new);
+
+        public Channel() {
+            super(GrimReloadEvent.class, Handler.class);
+        }
+
+        public void onReload(@NotNull GrimPlugin plugin, @NotNull Handler handler) {
+            subscribe(handler, 0, false, plugin, null);
+        }
+
+        public void onReload(@NotNull GrimPlugin plugin, @NotNull Handler handler, int priority) {
+            subscribe(handler, priority, false, plugin, null);
+        }
+
+        /** @deprecated resolve your context once at plugin enable — {@code api.getGrimPlugin(this)} — and call the {@link GrimPlugin}-taking overload. */
+        @Deprecated
+        public void onReload(@NotNull Object pluginContext, @NotNull Handler handler) {
+            onReload(resolvePlugin(pluginContext), handler);
+        }
+
+        /** @deprecated see {@link #onReload(Object, Handler)}. */
+        @Deprecated
+        public void onReload(@NotNull Object pluginContext, @NotNull Handler handler, int priority) {
+            onReload(resolvePlugin(pluginContext), handler, priority);
+        }
+
+        public void fire(boolean success) {
+            Entry<Handler>[] entries = entries();
+            if (entries.length == 0) return;
+            if (!hasLegacy()) {
+                for (Entry<Handler> e : entries) {
+                    try {
+                        e.handler.onReload(success);
+                    } catch (Throwable t) {
+                        t.printStackTrace();
+                    }
+                }
+                return;
+            }
+            GrimReloadEvent pooled = legacyPool.get();
+            pooled.init(success);
+            for (Entry<Handler> e : entries) {
+                try {
+                    if (e.legacyListener != null) {
+                        e.<GrimReloadEvent>legacyListenerAs().handle(pooled);
+                    } else {
+                        e.handler.onReload(success);
+                    }
+                } catch (Throwable t) {
+                    t.printStackTrace();
+                }
+            }
+        }
+
+        @Override
+        protected boolean dispatchTypedFromLegacy(@NotNull GrimReloadEvent event, @NotNull Handler handler, boolean cancelled) {
+            handler.onReload(event.isSuccess());
+            return false;
+        }
+
+        @ApiStatus.Internal
+        public static @NotNull Handler bridgeFromAny(@NotNull ac.grim.grimac.api.event.GrimEvent.Handler abstractHandler) {
+            return success -> abstractHandler.onAnyEvent(GrimReloadEvent.class, false);
+        }
     }
 }

--- a/src/main/java/ac/grim/grimac/api/event/events/GrimTeleportEvent.java
+++ b/src/main/java/ac/grim/grimac/api/event/events/GrimTeleportEvent.java
@@ -1,49 +1,76 @@
 package ac.grim.grimac.api.event.events;
 
 import ac.grim.grimac.api.GrimUser;
+import ac.grim.grimac.api.event.EventChannel;
 import ac.grim.grimac.api.event.GrimEvent;
+import ac.grim.grimac.api.plugin.GrimPlugin;
+import org.jetbrains.annotations.NotNull;
 
 /**
  * Fired when Grim sends a teleport packet to the client.
  *
- * <p>This event exists to help maintain compatibility with packet-based plugins and
- * other anticheats that keep track of inbound / outbound teleport packets to build a deque.</p>
+ * <p>Exists to help maintain compatibility with packet-based plugins and other
+ * anticheats that track inbound/outbound teleport packets to build a
+ * pending-teleport deque.
  *
- * <p>This event is fired on the Netty thread associated with the PacketEvents
- * user represented by the {@link GrimUser}.</p>
+ * <p>Fires on the Netty thread associated with the PacketEvents user.
+ * Observational, not cancellable.
  */
-public class GrimTeleportEvent extends GrimEvent implements GrimUserEvent {
-    private final GrimUser user;
-    private final int teleportId;
-    private final long timestamp;
-
-    public GrimTeleportEvent(GrimUser user, int teleportId, long timestamp) {
-        super();
-        this.user = user;
-        this.teleportId = teleportId;
-        this.timestamp = timestamp;
+public final class GrimTeleportEvent extends GrimEvent<GrimTeleportEvent.Channel> {
+    private GrimTeleportEvent() {
+        // Never instantiated — exists only as a Class key for bus.get(GrimTeleportEvent.class).
     }
 
-    @Override
-    public GrimUser getUser() {
-        return user;
+    @FunctionalInterface
+    public interface Handler {
+        void onTeleport(@NotNull GrimUser user, int teleportId, long timestamp);
     }
 
-    /**
-     * Returns the teleport id sent to the client.
-     *
-     * @return the teleport id that will be echoed in the teleport acknowledgement
-     */
-    public int getTeleportId() {
-        return teleportId;
-    }
+    public static final class Channel extends EventChannel<GrimTeleportEvent, Handler> {
+        public Channel() {
+            super(GrimTeleportEvent.class, Handler.class);
+        }
 
-    /**
-     * Returns the timestamp captured when the teleport packet was sent.
-     *
-     * @return the event timestamp in milliseconds
-     */
-    public long getTimestamp() {
-        return timestamp;
+        public void onTeleport(@NotNull GrimPlugin plugin, @NotNull Handler handler) {
+            subscribe(handler, 0, false, plugin, null);
+        }
+
+        public void onTeleport(@NotNull GrimPlugin plugin, @NotNull Handler handler, int priority) {
+            subscribe(handler, priority, false, plugin, null);
+        }
+
+        /** @deprecated resolve your context once at plugin enable — {@code api.getGrimPlugin(this)} — and call the {@link GrimPlugin}-taking overload. */
+        @Deprecated
+        public void onTeleport(@NotNull Object pluginContext, @NotNull Handler handler) {
+            onTeleport(resolvePlugin(pluginContext), handler);
+        }
+
+        /** @deprecated see {@link #onTeleport(Object, Handler)}. */
+        @Deprecated
+        public void onTeleport(@NotNull Object pluginContext, @NotNull Handler handler, int priority) {
+            onTeleport(resolvePlugin(pluginContext), handler, priority);
+        }
+
+        public void fire(@NotNull GrimUser user, int teleportId, long timestamp) {
+            Entry<Handler>[] entries = entries();
+            for (Entry<Handler> e : entries) {
+                try {
+                    e.handler.onTeleport(user, teleportId, timestamp);
+                } catch (Throwable t) {
+                    t.printStackTrace();
+                }
+            }
+        }
+
+        @Override
+        protected boolean dispatchTypedFromLegacy(@NotNull GrimTeleportEvent event, @NotNull Handler handler, boolean cancelled) {
+            // Unreachable — GrimTeleportEvent has no public constructor, so no caller can post() one.
+            throw new UnsupportedOperationException("GrimTeleportEvent has no legacy representation");
+        }
+
+        @org.jetbrains.annotations.ApiStatus.Internal
+        public static @NotNull Handler bridgeFromAny(@NotNull ac.grim.grimac.api.event.GrimEvent.Handler abstractHandler) {
+            return (user, id, ts) -> abstractHandler.onAnyEvent(GrimTeleportEvent.class, false);
+        }
     }
 }

--- a/src/main/java/ac/grim/grimac/api/event/events/GrimTransactionReceivedEvent.java
+++ b/src/main/java/ac/grim/grimac/api/event/events/GrimTransactionReceivedEvent.java
@@ -1,66 +1,78 @@
 package ac.grim.grimac.api.event.events;
 
 import ac.grim.grimac.api.GrimUser;
+import ac.grim.grimac.api.event.EventChannel;
 import ac.grim.grimac.api.event.GrimEvent;
+import ac.grim.grimac.api.plugin.GrimPlugin;
+import org.jetbrains.annotations.NotNull;
 
 /**
- * Fired when Grim receives an inbound response for a transaction packet that it
- * previously sent to the client.
+ * Fired when Grim receives an inbound response for a transaction packet that
+ * it previously sent.
  *
- * <p>Grim cancels these inbound packets by default. This behavior is
- * controlled by the {@code disable-pong-cancelling} option in
- * {@code config.yml}.</p>
+ * <p>Grim cancels these inbound packets by default, controlled by the
+ * {@code disable-pong-cancelling} option in {@code config.yml}. The
+ * {@code packetCancelled} parameter reflects whether Grim cancelled packet
+ * handling; it is not an event-cancellation flag (this event is observational
+ * and not cancellable).
  *
- * <p>This event only fires for transaction packets initiated by Grim.</p>
- *
- * <p>This event is fired on the Netty thread associated with the user
- * represented by the {@link GrimUser}.</p>
+ * <p>Only fires for transactions initiated by Grim, on the Netty thread
+ * associated with the user.
  */
-public class GrimTransactionReceivedEvent extends GrimEvent implements GrimUserEvent {
-    private final GrimUser user;
-    private final int transactionId;
-    private final boolean packetCancelled;
-    private final long timestamp;
-
-    public GrimTransactionReceivedEvent(GrimUser user, int transactionId, boolean packetCancelled, long timestamp) {
-        super();
-        this.user = user;
-        this.transactionId = transactionId;
-        this.packetCancelled = packetCancelled;
-        this.timestamp = timestamp;
+public final class GrimTransactionReceivedEvent extends GrimEvent<GrimTransactionReceivedEvent.Channel> {
+    private GrimTransactionReceivedEvent() {
+        // Never instantiated — exists only as a Class key for bus.get(GrimTransactionReceivedEvent.class).
     }
 
-    @Override
-    public GrimUser getUser() {
-        return user;
+    @FunctionalInterface
+    public interface Handler {
+        void onTransactionReceived(@NotNull GrimUser user, int transactionId, boolean packetCancelled, long timestamp);
     }
 
-    /**
-     * Returns the id of the transaction packet this inbound response belongs to.
-     *
-     * @return the transaction id echoed back by the client
-     */
-    public int getTransactionId() {
-        return transactionId;
-    }
+    public static final class Channel extends EventChannel<GrimTransactionReceivedEvent, Handler> {
+        public Channel() {
+            super(GrimTransactionReceivedEvent.class, Handler.class);
+        }
 
-    /**
-     * Returns whether Grim cancelled handling of the inbound transaction packet.
-     *
-     * <p>This flag describes packet handling, not event cancellation.</p>
-     *
-     * @return {@code true} if Grim cancelled the inbound packet
-     */
-    public boolean isPacketCancelled() {
-        return packetCancelled;
-    }
+        public void onTransactionReceived(@NotNull GrimPlugin plugin, @NotNull Handler handler) {
+            subscribe(handler, 0, false, plugin, null);
+        }
 
-    /**
-     * Returns the timestamp captured when the inbound transaction packet was received.
-     *
-     * @return the event timestamp in milliseconds
-     */
-    public long getTimestamp() {
-        return timestamp;
+        public void onTransactionReceived(@NotNull GrimPlugin plugin, @NotNull Handler handler, int priority) {
+            subscribe(handler, priority, false, plugin, null);
+        }
+
+        /** @deprecated resolve your context once at plugin enable — {@code api.getGrimPlugin(this)} — and call the {@link GrimPlugin}-taking overload. */
+        @Deprecated
+        public void onTransactionReceived(@NotNull Object pluginContext, @NotNull Handler handler) {
+            onTransactionReceived(resolvePlugin(pluginContext), handler);
+        }
+
+        /** @deprecated see {@link #onTransactionReceived(Object, Handler)}. */
+        @Deprecated
+        public void onTransactionReceived(@NotNull Object pluginContext, @NotNull Handler handler, int priority) {
+            onTransactionReceived(resolvePlugin(pluginContext), handler, priority);
+        }
+
+        public void fire(@NotNull GrimUser user, int transactionId, boolean packetCancelled, long timestamp) {
+            Entry<Handler>[] entries = entries();
+            for (Entry<Handler> e : entries) {
+                try {
+                    e.handler.onTransactionReceived(user, transactionId, packetCancelled, timestamp);
+                } catch (Throwable t) {
+                    t.printStackTrace();
+                }
+            }
+        }
+
+        @Override
+        protected boolean dispatchTypedFromLegacy(@NotNull GrimTransactionReceivedEvent event, @NotNull Handler handler, boolean cancelled) {
+            throw new UnsupportedOperationException("GrimTransactionReceivedEvent has no legacy representation");
+        }
+
+        @org.jetbrains.annotations.ApiStatus.Internal
+        public static @NotNull Handler bridgeFromAny(@NotNull ac.grim.grimac.api.event.GrimEvent.Handler abstractHandler) {
+            return (user, id, c, ts) -> abstractHandler.onAnyEvent(GrimTransactionReceivedEvent.class, false);
+        }
     }
 }

--- a/src/main/java/ac/grim/grimac/api/event/events/GrimTransactionSendEvent.java
+++ b/src/main/java/ac/grim/grimac/api/event/events/GrimTransactionSendEvent.java
@@ -1,50 +1,75 @@
 package ac.grim.grimac.api.event.events;
 
 import ac.grim.grimac.api.GrimUser;
+import ac.grim.grimac.api.event.EventChannel;
 import ac.grim.grimac.api.event.GrimEvent;
+import ac.grim.grimac.api.plugin.GrimPlugin;
+import org.jetbrains.annotations.NotNull;
 
 /**
  * Fired when Grim sends a transaction packet to the client.
  *
  * <p>Plugins can use this event to track transaction ids issued by Grim and
  * correlate them with the matching {@link GrimTransactionReceivedEvent} once a
- * response is received.</p>
+ * response is received.
  *
- * <p>This event is fired on the Netty thread associated with the user
- * represented by the {@link GrimUser}.</p>
+ * <p>Fires on the Netty thread associated with the user. Observational, not
+ * cancellable.
  */
-public class GrimTransactionSendEvent extends GrimEvent implements GrimUserEvent {
-    private final GrimUser user;
-    private final int transactionId;
-    private final long timestamp;
-
-    public GrimTransactionSendEvent(GrimUser user, int transactionId, long timestamp) {
-        super();
-        this.user = user;
-        this.transactionId = transactionId;
-        this.timestamp = timestamp;
+public final class GrimTransactionSendEvent extends GrimEvent<GrimTransactionSendEvent.Channel> {
+    private GrimTransactionSendEvent() {
+        // Never instantiated — exists only as a Class key for bus.get(GrimTransactionSendEvent.class).
     }
 
-    @Override
-    public GrimUser getUser() {
-        return user;
+    @FunctionalInterface
+    public interface Handler {
+        void onTransactionSend(@NotNull GrimUser user, int transactionId, long timestamp);
     }
 
-    /**
-     * Returns the id of the transaction packet sent to the client.
-     *
-     * @return the outbound transaction id
-     */
-    public int getTransactionId() {
-        return transactionId;
-    }
+    public static final class Channel extends EventChannel<GrimTransactionSendEvent, Handler> {
+        public Channel() {
+            super(GrimTransactionSendEvent.class, Handler.class);
+        }
 
-    /**
-     * Returns the timestamp captured when the transaction packet was sent.
-     *
-     * @return the event timestamp in milliseconds
-     */
-    public long getTimestamp() {
-        return timestamp;
+        public void onTransactionSend(@NotNull GrimPlugin plugin, @NotNull Handler handler) {
+            subscribe(handler, 0, false, plugin, null);
+        }
+
+        public void onTransactionSend(@NotNull GrimPlugin plugin, @NotNull Handler handler, int priority) {
+            subscribe(handler, priority, false, plugin, null);
+        }
+
+        /** @deprecated resolve your context once at plugin enable — {@code api.getGrimPlugin(this)} — and call the {@link GrimPlugin}-taking overload. */
+        @Deprecated
+        public void onTransactionSend(@NotNull Object pluginContext, @NotNull Handler handler) {
+            onTransactionSend(resolvePlugin(pluginContext), handler);
+        }
+
+        /** @deprecated see {@link #onTransactionSend(Object, Handler)}. */
+        @Deprecated
+        public void onTransactionSend(@NotNull Object pluginContext, @NotNull Handler handler, int priority) {
+            onTransactionSend(resolvePlugin(pluginContext), handler, priority);
+        }
+
+        public void fire(@NotNull GrimUser user, int transactionId, long timestamp) {
+            Entry<Handler>[] entries = entries();
+            for (Entry<Handler> e : entries) {
+                try {
+                    e.handler.onTransactionSend(user, transactionId, timestamp);
+                } catch (Throwable t) {
+                    t.printStackTrace();
+                }
+            }
+        }
+
+        @Override
+        protected boolean dispatchTypedFromLegacy(@NotNull GrimTransactionSendEvent event, @NotNull Handler handler, boolean cancelled) {
+            throw new UnsupportedOperationException("GrimTransactionSendEvent has no legacy representation");
+        }
+
+        @org.jetbrains.annotations.ApiStatus.Internal
+        public static @NotNull Handler bridgeFromAny(@NotNull ac.grim.grimac.api.event.GrimEvent.Handler abstractHandler) {
+            return (user, id, ts) -> abstractHandler.onAnyEvent(GrimTransactionSendEvent.class, false);
+        }
     }
 }

--- a/src/main/java/ac/grim/grimac/api/event/events/GrimVerboseCheckEvent.java
+++ b/src/main/java/ac/grim/grimac/api/event/events/GrimVerboseCheckEvent.java
@@ -2,16 +2,84 @@ package ac.grim.grimac.api.event.events;
 
 import ac.grim.grimac.api.AbstractCheck;
 import ac.grim.grimac.api.GrimUser;
+import ac.grim.grimac.api.event.AbstractEventChannel;
+import ac.grim.grimac.api.event.EventChannel;
+import ac.grim.grimac.api.plugin.GrimPlugin;
+import org.jetbrains.annotations.ApiStatus;
+import org.jetbrains.annotations.NotNull;
 
-public abstract class GrimVerboseCheckEvent extends GrimCheckEvent {
-    private final String verbose;
+public abstract class GrimVerboseCheckEvent<CHANNEL extends EventChannel<?, ?>>
+        extends GrimCheckEvent<CHANNEL> {
+    private String verbose;
+
+    /** Pool constructor — fields populated via {@link #init(GrimUser, AbstractCheck, String)}. */
+    protected GrimVerboseCheckEvent() {
+        super();
+    }
 
     public GrimVerboseCheckEvent(GrimUser user, AbstractCheck check, String verbose) {
         super(user, check);
         this.verbose = verbose;
     }
 
+    @ApiStatus.Internal
+    protected void init(GrimUser user, AbstractCheck check, String verbose) {
+        super.init(user, check);
+        this.verbose = verbose;
+    }
+
     public String getVerbose() {
         return verbose;
+    }
+
+    /**
+     * Abstract-level verbose-check handler. Fires for every concrete
+     * {@code GrimVerboseCheckEvent} subtype — FlagEvent and
+     * CommandExecuteEvent out of the box, plus any addon subtypes that
+     * opt into bridging. Does not fire for
+     * {@link CompletePredictionEvent}, which extends {@link GrimCheckEvent}
+     * directly and has no verbose field.
+     */
+    @FunctionalInterface
+    public interface Handler {
+        boolean onVerboseCheck(@NotNull GrimUser user, @NotNull AbstractCheck check,
+                               @NotNull String verbose, boolean currentlyCancelled);
+    }
+
+    public static final class Channel extends AbstractEventChannel<GrimVerboseCheckEvent<?>, Handler> {
+        @SuppressWarnings({"unchecked", "rawtypes"})
+        public Channel() {
+            super((Class<GrimVerboseCheckEvent<?>>) (Class) GrimVerboseCheckEvent.class, Handler.class);
+        }
+
+        public void onVerboseCheck(@NotNull GrimPlugin plugin, @NotNull Handler handler) {
+            subscribeAbstract(handler, 0, false, plugin);
+        }
+
+        public void onVerboseCheck(@NotNull GrimPlugin plugin, @NotNull Handler handler, int priority) {
+            subscribeAbstract(handler, priority, false, plugin);
+        }
+
+        public void onVerboseCheck(@NotNull GrimPlugin plugin, @NotNull Handler handler, int priority, boolean ignoreCancelled) {
+            subscribeAbstract(handler, priority, ignoreCancelled, plugin);
+        }
+
+        /** @deprecated resolve your context once at plugin enable — {@code api.getGrimPlugin(this)} — and call the {@link GrimPlugin}-taking overload. */
+        @Deprecated
+        public void onVerboseCheck(@NotNull Object pluginContext, @NotNull Handler handler) {
+            subscribeAbstractResolving(pluginContext, handler, 0, false);
+        }
+
+        /** @deprecated see {@link #onVerboseCheck(Object, Handler)}. */
+        @Deprecated
+        public void onVerboseCheck(@NotNull Object pluginContext, @NotNull Handler handler, int priority) {
+            subscribeAbstractResolving(pluginContext, handler, priority, false);
+        }
+
+        /** @deprecated see {@link #onVerboseCheck(Object, Handler)}. */
+        @Deprecated
+        public void onVerboseCheck(@NotNull Object pluginContext, @NotNull Handler handler, int priority, boolean ignoreCancelled) {
+            subscribeAbstractResolving(pluginContext, handler, priority, ignoreCancelled);
+        }
     }
 }


### PR DESCRIPTION
Picks up where #19 left off. Each event gets its own `EventChannel`
subclass that exposes a typed `fire(user, check, verbose, ...)` — the
hot path is a volatile read + direct method invoke, no per-fire
allocation, no reflection. The legacy `bus.post(...)` /
`bus.subscribe(Class, listener)` / `@GrimEventHandler` paths all keep
working as `@Deprecated` shims that route through each channel's legacy
slot.

### Usage

```java
GrimAbstractAPI api = GrimAPIProvider.get();
EventBus bus = api.getEventBus();
GrimPlugin grim = api.getGrimPlugin(this);   // resolve once at plugin enable

bus.get(FlagEvent.class).onFlag(grim, (user, check, verbose, cancelled) -> {
    if (shouldSuppress(user, check)) return true;   // cancel
    return cancelled;
});
```

Every typed subscribe takes a `GrimPlugin` so `bus.unregisterAllListeners(grim)`
sweeps it on disable, same shape as Bukkit's `HandlerList`. Plugin
authors that want to pass a platform-specific context (Bukkit
`JavaPlugin`, Fabric `ModContainer`, a `Class`) can use the
`@Deprecated onX(Object ctx, Handler)` overload that resolves through
the bus's extension manager — the warning is there to nudge toward
`api.getGrimPlugin(this)`-once-and-cache.

### Abstract-event subscribe

`GrimCheckEvent`, `GrimVerboseCheckEvent`, and `GrimEvent` each have a
nested `Handler` + `Channel` that fires for every concrete subtype:

```java
GrimCheckEvent.Channel abs = (GrimCheckEvent.Channel) bus.get(GrimCheckEvent.class);
abs.onCheck(grim, (user, check, cancelled) -> {
    // fires for FlagEvent, CompletePredictionEvent, CommandExecuteEvent,
    // and any addon subtype that registers via abs.registerSubtype(...)
    return cancelled;
});

// Root-level observer — useful for metrics / debug:
GrimEvent.Channel any = (GrimEvent.Channel) bus.get(GrimEvent.class);
any.onAnyEvent(grim, (eventClass, cancelled) -> counts.computeIfAbsent(eventClass, c -> new LongAdder()).increment());
```

Implementation is the bridge-listener pattern — at abstract subscribe
time, a concrete-typed bridge entry is installed into every registered
child channel. The hot path (`child.fire(...)`) iterates its `Entry[]`
unchanged; bridges are indistinguishable from direct subscribers for
sort order, priority, and cancellation. Late-registered subtypes (addon
check types) walk the existing abstract-subscriber list and get covered
automatically.

### Hot path / caching

```java
private static final FlagEvent.Channel FLAG =
    GrimAPIProvider.get().getEventBus().get(FlagEvent.class);

// later, on the netty thread:
FLAG.fire(user, check, verbose);
```

`static final` so the JIT folds the getfield.

### Priority ordering flips

Lower number fires first, higher gets the final say — Bukkit
`EventPriority` convention (`LOWEST → LOW → NORMAL → HIGH → HIGHEST →
MONITOR`). Pre-1.3 Grim sorted highest-first. Plugins using default
priority (0) are unaffected; anyone with explicit numbers on
`@GrimEventHandler` / `bus.subscribe(...)` needs to re-evaluate.

### No reflection on the dispatch path

`OptimizedEventBus` constructor `new`s each channel explicitly:

```java
installChannel(FlagEvent.class, new FlagEvent.Channel());
installChannel(CommandExecuteEvent.class, new CommandExecuteEvent.Channel());
// ... 9 concrete + 3 abstract
```

So renaming `FlagEvent.Channel` breaks at compile time, not at runtime,
and ProGuard/tree-shakers keep everything reachable from the
constructor. Bridge factories are plain static method references
(`FlagEvent.Channel::bridgeFromCheck`) — also obfuscation-safe.
`bus.get(E.class)` is a `ConcurrentHashMap` lookup keyed on the Class
identity. The only `getDeclaredMethods` / `MethodHandle.invoke` live in
the `@Deprecated registerAnnotatedListeners` path — opt-in, for
back-compat with plugins using `@GrimEventHandler`.

### JMH

```
Benchmark                    (mode)  (subscribers)  Mode  Cnt    Score  Units
EventDispatchBenchmark.fire   typed              0  avgt    3    2.17  ns/op
EventDispatchBenchmark.fire   typed              1  avgt    3    7.19  ns/op
EventDispatchBenchmark.fire   typed              3  avgt    3   13.51  ns/op
EventDispatchBenchmark.fire  legacy              1  avgt    3   15.05  ns/op
EventDispatchBenchmark.fire  legacy              3  avgt    3   21.99  ns/op
EventDispatchBenchmark.fire   mixed              3  avgt    3   18.39  ns/op
```

With `-prof gc`: `gc.count ≈ 0`, `gc.alloc.rate.norm ≈ 10⁻⁵ B/op` — the
residual is JMH infrastructure noise, not dispatch overhead. Zero-alloc
fire confirmed across typed / legacy / mixed configurations.

### Tests

21 unit tests in `grim-internal/src/test` — each pins a one-line-change
regression the compiler can't catch:

- priority sort direction + typed/legacy mixed dispatch (10)
- bus routing + reflective `@GrimEventHandler` + plugin-disable sweep (8)
- bridge-pattern: abstract-first, subtype-first, unsubscribe-sweep (3)

### End-to-end

Against `paper-1.21.11` + a reference plugin wired to every channel and
both abstract-subscribe paths:

- `api-event-fire` PASS — Join / Quit / Reload / TxSend / TxRecv end-to-end
- `api-legacy-compat` PASS — `@GrimEventHandler` still dispatches
- `api-flag-event` PASS — cancellable `FlagEvent.onFlag(grim, ...)` fires on Wurst Flight
- `api-abstract-subscribe` PASS — `GrimEvent.onAnyEvent` fires on Join, `GrimCheckEvent.onCheck` fires on flag

### Related

Grim-side migration PR that consumes this: GrimAnticheat/Grim#2612