### PR TITLE
mysql: MariaDB 10.6+ support + unify on STORED gen col (v7→v8 migration)

### DIFF
--- a/grim-internal/src/main/java/ac/grim/grimac/internal/storage/backend/mysql/MariaDbDialect.java
+++ b/grim-internal/src/main/java/ac/grim/grimac/internal/storage/backend/mysql/MariaDbDialect.java
@@ -1,0 +1,148 @@
+package ac.grim.grimac.internal.storage.backend.mysql;
+
+import ac.grim.grimac.api.storage.config.TableNames;
+import org.jetbrains.annotations.ApiStatus;
+
+import java.sql.SQLException;
+import java.sql.Statement;
+
+/**
+ * MariaDB 10.6+ dialect. MariaDB doesn't implement either of the two MySQL-8
+ * features that {@link MysqlEightDialect} relies on:
+ * <ul>
+ *   <li>Functional indexes ({@code INDEX … ((LOWER(col)))}) — MariaDB tracks
+ *       this as <a href="https://jira.mariadb.org/browse/MDEV-22597">MDEV-22597</a>
+ *       (still open at the time of writing). The portable MariaDB equivalent
+ *       is a {@code STORED} generated column with a plain B-tree index.</li>
+ *   <li>The aliased-row upsert form ({@code … AS new ON DUPLICATE KEY UPDATE
+ *       col = new.col}) — MariaDB never adopted MySQL 8.0.19's syntax. The
+ *       legacy {@code … ON DUPLICATE KEY UPDATE col = VALUES(col)} form,
+ *       deprecated in MySQL 8.0.20 but never deprecated in MariaDB, works on
+ *       both engines and is what we emit here.</li>
+ * </ul>
+ * Floor of 10.6: that's the oldest MariaDB LTS still in upstream support,
+ * comfortably above the {@code STORED} generated-column floor (10.2.1) and
+ * the enforced {@code CHECK} floor (10.2.1) we depend on. 11.x and 12.x are
+ * supersets of the same DDL — no further version splits needed.
+ */
+@ApiStatus.Internal
+final class MariaDbDialect implements MysqlDialect {
+
+    @Override
+    public void applyBaseline(Statement s, TableNames t) throws SQLException {
+        s.executeUpdate("CREATE TABLE " + t.checks() + " ("
+                + "check_id INT AUTO_INCREMENT PRIMARY KEY, "
+                + "stable_key VARCHAR(255) NOT NULL UNIQUE, "
+                + "display VARCHAR(255), "
+                + "description VARCHAR(1024), "
+                + "introduced_version VARCHAR(64), "
+                + "removed_version VARCHAR(64), "
+                + "introduced_at BIGINT"
+                + ") ENGINE=InnoDB DEFAULT CHARSET=utf8mb4");
+
+        // STORED generated column — auto-populated on INSERT, write path stays
+        // identical (only uuid/current_name/first_seen/last_seen get bound).
+        // The plain B-tree index on current_name_lower carries WHERE
+        // current_name_lower = ? and WHERE current_name_lower LIKE 'x%' the
+        // same way MySQL's functional index does — verified via EXPLAIN on
+        // 10.11. Note: MariaDB does NOT rewrite WHERE LOWER(current_name)=?
+        // to use this index (full table scan), so the read queries below
+        // reference current_name_lower directly.
+        s.executeUpdate("CREATE TABLE " + t.players() + " ("
+                + "uuid BINARY(16) PRIMARY KEY, "
+                + "current_name VARCHAR(32), "
+                + "current_name_lower VARCHAR(32) AS (LOWER(current_name)) STORED, "
+                + "first_seen BIGINT NOT NULL, "
+                + "last_seen BIGINT NOT NULL, "
+                + "INDEX idx_" + t.players() + "_name_lower (current_name_lower)"
+                + ") ENGINE=InnoDB DEFAULT CHARSET=utf8mb4");
+
+        s.executeUpdate("CREATE TABLE " + t.sessions() + " ("
+                + "session_id BINARY(16) PRIMARY KEY, "
+                + "player_uuid BINARY(16) NOT NULL, "
+                + "server_name VARCHAR(64), "
+                + "started_at BIGINT NOT NULL, "
+                + "last_activity BIGINT NOT NULL, "
+                + "closed_at BIGINT NULL, "
+                + "grim_version VARCHAR(64), "
+                + "client_brand VARCHAR(64), "
+                + "client_version_pvn INT NOT NULL DEFAULT -1, "
+                + "server_version VARCHAR(64), "
+                + "replay_clips_json MEDIUMTEXT, "
+                + "INDEX idx_" + t.sessions() + "_player_started (player_uuid, started_at DESC)"
+                + ") ENGINE=InnoDB DEFAULT CHARSET=utf8mb4");
+
+        s.executeUpdate("CREATE TABLE " + t.violations() + " ("
+                + "id BIGINT AUTO_INCREMENT PRIMARY KEY, "
+                + "session_id BINARY(16) NOT NULL, "
+                + "player_uuid BINARY(16) NOT NULL, "
+                + "check_id INT NOT NULL, "
+                + "vl DOUBLE NOT NULL, "
+                + "occurred_at BIGINT NOT NULL, "
+                + "verbose MEDIUMTEXT, "
+                + "verbose_format INT NOT NULL DEFAULT 0, "
+                + "metadata MEDIUMTEXT, "
+                + "INDEX idx_" + t.violations() + "_session_time (session_id, occurred_at), "
+                + "INDEX idx_" + t.violations() + "_player (player_uuid)"
+                + ") ENGINE=InnoDB DEFAULT CHARSET=utf8mb4");
+
+        s.executeUpdate("CREATE TABLE " + t.settings() + " ("
+                + "scope VARCHAR(16) NOT NULL, "
+                + "scope_key VARCHAR(128) NOT NULL, "
+                + "`key` VARCHAR(128) NOT NULL, "
+                + "value LONGBLOB NOT NULL, "
+                + "updated_at BIGINT NOT NULL, "
+                + "PRIMARY KEY (scope, scope_key, `key`)"
+                + ") ENGINE=InnoDB DEFAULT CHARSET=utf8mb4");
+    }
+
+    @Override
+    public String upsertSessions(TableNames t) {
+        return "INSERT INTO " + t.sessions() + "(session_id, player_uuid, server_name, started_at, last_activity, closed_at, "
+                + "grim_version, client_brand, client_version_pvn, server_version, replay_clips_json) "
+                + "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?) "
+                + "ON DUPLICATE KEY UPDATE "
+                + "server_name=VALUES(server_name), "
+                + "last_activity=VALUES(last_activity), "
+                // closed_at: NULL → set transitions only; never overwrite an
+                // already-closed row with NULL on a late heartbeat.
+                + "closed_at=COALESCE(" + t.sessions() + ".closed_at, VALUES(closed_at)), "
+                + "grim_version=VALUES(grim_version), "
+                + "client_brand=VALUES(client_brand), "
+                + "client_version_pvn=VALUES(client_version_pvn), "
+                + "server_version=VALUES(server_version), "
+                + "replay_clips_json=VALUES(replay_clips_json)";
+    }
+
+    @Override
+    public String upsertIdentities(TableNames t) {
+        return "INSERT INTO " + t.players() + "(uuid, current_name, first_seen, last_seen) "
+                + "VALUES (?, ?, ?, ?) "
+                + "ON DUPLICATE KEY UPDATE "
+                + "current_name = VALUES(current_name), "
+                + "first_seen = LEAST(" + t.players() + ".first_seen, VALUES(first_seen)), "
+                + "last_seen = GREATEST(" + t.players() + ".last_seen, VALUES(last_seen))";
+    }
+
+    @Override
+    public String upsertSettings(TableNames t) {
+        return "INSERT INTO " + t.settings() + "(scope, scope_key, `key`, value, updated_at) "
+                + "VALUES (?, ?, ?, ?, ?) "
+                + "ON DUPLICATE KEY UPDATE "
+                + "value = VALUES(value), "
+                + "updated_at = VALUES(updated_at)";
+    }
+
+    @Override
+    public String selectIdentityByName(TableNames t) {
+        return "SELECT uuid, current_name, first_seen, last_seen FROM " + t.players() + " "
+                + "WHERE current_name_lower = ? ORDER BY last_seen DESC LIMIT 1";
+    }
+
+    @Override
+    public String selectIdentitiesByNamePrefix(TableNames t) {
+        return "SELECT uuid, current_name, first_seen, last_seen FROM " + t.players() + " "
+                + "WHERE current_name_lower LIKE ? ESCAPE '\\\\' "
+                + "ORDER BY last_seen DESC LIMIT ?";
+    }
+}

--- a/grim-internal/src/main/java/ac/grim/grimac/internal/storage/backend/mysql/MariaDbDialect.java
+++ b/grim-internal/src/main/java/ac/grim/grimac/internal/storage/backend/mysql/MariaDbDialect.java
@@ -3,98 +3,24 @@ package ac.grim.grimac.internal.storage.backend.mysql;
 import ac.grim.grimac.api.storage.config.TableNames;
 import org.jetbrains.annotations.ApiStatus;
 
-import java.sql.SQLException;
-import java.sql.Statement;
-
 /**
- * MariaDB 10.6+ dialect. MariaDB doesn't implement either of the two MySQL-8
- * features that {@link MysqlEightDialect} relies on:
- * <ul>
- *   <li>Functional indexes ({@code INDEX … ((LOWER(col)))}) — MariaDB tracks
- *       this as <a href="https://jira.mariadb.org/browse/MDEV-22597">MDEV-22597</a>
- *       (still open at the time of writing). The portable MariaDB equivalent
- *       is a {@code STORED} generated column with a plain B-tree index.</li>
- *   <li>The aliased-row upsert form ({@code … AS new ON DUPLICATE KEY UPDATE
- *       col = new.col}) — MariaDB never adopted MySQL 8.0.19's syntax. The
- *       legacy {@code … ON DUPLICATE KEY UPDATE col = VALUES(col)} form,
- *       deprecated in MySQL 8.0.20 but never deprecated in MariaDB, works on
- *       both engines and is what we emit here.</li>
- * </ul>
- * Floor of 10.6: that's the oldest MariaDB LTS still in upstream support,
- * comfortably above the {@code STORED} generated-column floor (10.2.1) and
- * the enforced {@code CHECK} floor (10.2.1) we depend on. 11.x and 12.x are
- * supersets of the same DDL — no further version splits needed.
+ * MariaDB 10.6+ dialect. Inherits the v8 baseline DDL and read SQL from
+ * {@link MysqlDialect}; the only divergence from {@link MysqlEightDialect}
+ * is the upsert syntax, which uses the legacy {@code VALUES()} reference
+ * because MariaDB never adopted the MySQL 8.0.19 aliased-row form.
+ * <p>
+ * Inherits the no-op {@code migrateV7ToV8} from {@link MysqlDialect} —
+ * MariaDB v7 deployments already had the v8 column layout (its dialect was
+ * always at the gen col shape), so no schema rewrite is needed; only the
+ * meta table's schema_version row gets bumped.
+ * <p>
+ * Floor of 10.6: oldest MariaDB LTS still in upstream support, comfortably
+ * above the {@code STORED} generated-column floor (10.2.1) and the enforced
+ * {@code CHECK} floor (10.2.1) we depend on. 11.x and 12.x are supersets of
+ * the same DDL — no further version splits needed.
  */
 @ApiStatus.Internal
 final class MariaDbDialect implements MysqlDialect {
-
-    @Override
-    public void applyBaseline(Statement s, TableNames t) throws SQLException {
-        s.executeUpdate("CREATE TABLE " + t.checks() + " ("
-                + "check_id INT AUTO_INCREMENT PRIMARY KEY, "
-                + "stable_key VARCHAR(255) NOT NULL UNIQUE, "
-                + "display VARCHAR(255), "
-                + "description VARCHAR(1024), "
-                + "introduced_version VARCHAR(64), "
-                + "removed_version VARCHAR(64), "
-                + "introduced_at BIGINT"
-                + ") ENGINE=InnoDB DEFAULT CHARSET=utf8mb4");
-
-        // STORED generated column — auto-populated on INSERT, write path stays
-        // identical (only uuid/current_name/first_seen/last_seen get bound).
-        // The plain B-tree index on current_name_lower carries WHERE
-        // current_name_lower = ? and WHERE current_name_lower LIKE 'x%' the
-        // same way MySQL's functional index does — verified via EXPLAIN on
-        // 10.11. Note: MariaDB does NOT rewrite WHERE LOWER(current_name)=?
-        // to use this index (full table scan), so the read queries below
-        // reference current_name_lower directly.
-        s.executeUpdate("CREATE TABLE " + t.players() + " ("
-                + "uuid BINARY(16) PRIMARY KEY, "
-                + "current_name VARCHAR(32), "
-                + "current_name_lower VARCHAR(32) AS (LOWER(current_name)) STORED, "
-                + "first_seen BIGINT NOT NULL, "
-                + "last_seen BIGINT NOT NULL, "
-                + "INDEX idx_" + t.players() + "_name_lower (current_name_lower)"
-                + ") ENGINE=InnoDB DEFAULT CHARSET=utf8mb4");
-
-        s.executeUpdate("CREATE TABLE " + t.sessions() + " ("
-                + "session_id BINARY(16) PRIMARY KEY, "
-                + "player_uuid BINARY(16) NOT NULL, "
-                + "server_name VARCHAR(64), "
-                + "started_at BIGINT NOT NULL, "
-                + "last_activity BIGINT NOT NULL, "
-                + "closed_at BIGINT NULL, "
-                + "grim_version VARCHAR(64), "
-                + "client_brand VARCHAR(64), "
-                + "client_version_pvn INT NOT NULL DEFAULT -1, "
-                + "server_version VARCHAR(64), "
-                + "replay_clips_json MEDIUMTEXT, "
-                + "INDEX idx_" + t.sessions() + "_player_started (player_uuid, started_at DESC)"
-                + ") ENGINE=InnoDB DEFAULT CHARSET=utf8mb4");
-
-        s.executeUpdate("CREATE TABLE " + t.violations() + " ("
-                + "id BIGINT AUTO_INCREMENT PRIMARY KEY, "
-                + "session_id BINARY(16) NOT NULL, "
-                + "player_uuid BINARY(16) NOT NULL, "
-                + "check_id INT NOT NULL, "
-                + "vl DOUBLE NOT NULL, "
-                + "occurred_at BIGINT NOT NULL, "
-                + "verbose MEDIUMTEXT, "
-                + "verbose_format INT NOT NULL DEFAULT 0, "
-                + "metadata MEDIUMTEXT, "
-                + "INDEX idx_" + t.violations() + "_session_time (session_id, occurred_at), "
-                + "INDEX idx_" + t.violations() + "_player (player_uuid)"
-                + ") ENGINE=InnoDB DEFAULT CHARSET=utf8mb4");
-
-        s.executeUpdate("CREATE TABLE " + t.settings() + " ("
-                + "scope VARCHAR(16) NOT NULL, "
-                + "scope_key VARCHAR(128) NOT NULL, "
-                + "`key` VARCHAR(128) NOT NULL, "
-                + "value LONGBLOB NOT NULL, "
-                + "updated_at BIGINT NOT NULL, "
-                + "PRIMARY KEY (scope, scope_key, `key`)"
-                + ") ENGINE=InnoDB DEFAULT CHARSET=utf8mb4");
-    }
 
     @Override
     public String upsertSessions(TableNames t) {
@@ -131,18 +57,5 @@ final class MariaDbDialect implements MysqlDialect {
                 + "ON DUPLICATE KEY UPDATE "
                 + "value = VALUES(value), "
                 + "updated_at = VALUES(updated_at)";
-    }
-
-    @Override
-    public String selectIdentityByName(TableNames t) {
-        return "SELECT uuid, current_name, first_seen, last_seen FROM " + t.players() + " "
-                + "WHERE current_name_lower = ? ORDER BY last_seen DESC LIMIT 1";
-    }
-
-    @Override
-    public String selectIdentitiesByNamePrefix(TableNames t) {
-        return "SELECT uuid, current_name, first_seen, last_seen FROM " + t.players() + " "
-                + "WHERE current_name_lower LIKE ? ESCAPE '\\\\' "
-                + "ORDER BY last_seen DESC LIMIT ?";
     }
 }

--- a/grim-internal/src/main/java/ac/grim/grimac/internal/storage/backend/mysql/MysqlBackend.java
+++ b/grim-internal/src/main/java/ac/grim/grimac/internal/storage/backend/mysql/MysqlBackend.java
@@ -133,16 +133,74 @@ public final class MysqlBackend implements Backend {
         synchronized (writeMutex) {
             try {
                 this.writeConn = openConnection();
-                this.dialect = new MysqlEightDialect();
+                this.dialect = selectDialect(writeConn, ctx.logger());
                 TableNames t = config.tableNames();
                 this.upsertSessions = dialect.upsertSessions(t);
                 this.upsertIdentities = dialect.upsertIdentities(t);
                 this.upsertSettings = dialect.upsertSettings(t);
                 MysqlSchema.ensureInitialized(writeConn, "phase1", t, dialect);
+            } catch (BackendException be) {
+                throw be;
             } catch (SQLException e) {
                 throw new BackendException("failed to initialise MySQL backend", e);
             }
         }
+    }
+
+    /**
+     * Probe {@code SELECT VERSION()} and pick the matching dialect. MariaDB
+     * 10.6+ goes through {@link MariaDbDialect}; everything else routes through
+     * {@link MysqlEightDialect}. MariaDB older than 10.6 is rejected — the
+     * STORED-generated-column DDL needs 10.2.1+ at the absolute minimum, and
+     * 10.6 is the oldest LTS still in upstream support.
+     * <p>
+     * Mirrors {@link ac.grim.grimac.internal.storage.backend.sqlite.SqliteBackend}'s
+     * dialect-selector pattern; see that class for the fuller rationale on
+     * version-driven dialect splits over compile-time forks.
+     */
+    static MysqlDialect selectDialect(Connection c, java.util.logging.Logger log) throws SQLException, BackendException {
+        String version;
+        try (java.sql.Statement s = c.createStatement();
+             java.sql.ResultSet rs = s.executeQuery("SELECT VERSION()")) {
+            version = rs.next() ? rs.getString(1) : "";
+        }
+        boolean mariaDb = version.contains("MariaDB");
+        if (!mariaDb) {
+            log.info("[grim-datastore] MySQL engine " + version + " — using MySQL 8 dialect");
+            return new MysqlEightDialect();
+        }
+        // MariaDB version strings:
+        //   "10.11.16-MariaDB-ubu2204"           — modern
+        //   "5.5.5-10.11.16-MariaDB-…"           — legacy compat prefix the
+        //                                          server prepends to fool old
+        //                                          MySQL client libs (see
+        //                                          MDEV-9788). Strip it.
+        String triplePart = version.startsWith("5.5.5-") ? version.substring("5.5.5-".length()) : version;
+        int dash = triplePart.indexOf('-');
+        if (dash > 0) triplePart = triplePart.substring(0, dash);
+        int[] triple = parseTriple(triplePart);
+        int major = triple[0], minor = triple[1];
+        if (major < 10 || (major == 10 && minor < 6)) {
+            throw new BackendException("MariaDB " + version + " is too old; minimum supported is 10.6 "
+                    + "(STORED generated columns require 10.2.1, 10.6 is the oldest LTS still in upstream support). "
+                    + "Upgrade MariaDB or point Grim at a different storage backend.");
+        }
+        log.info("[grim-datastore] MariaDB engine " + version + " — using MariaDB dialect");
+        return new MariaDbDialect();
+    }
+
+    private static int[] parseTriple(String version) {
+        int[] triple = {0, 0, 0};
+        int idx = 0, i = 0;
+        while (i < version.length() && idx < 3) {
+            int start = i;
+            while (i < version.length() && Character.isDigit(version.charAt(i))) i++;
+            if (i == start) break;
+            triple[idx++] = Integer.parseInt(version.substring(start, i));
+            if (i < version.length() && version.charAt(i) == '.') i++;
+            else break;
+        }
+        return triple;
     }
 
     /**
@@ -794,5 +852,11 @@ public final class MysqlBackend implements Backend {
     @ApiStatus.Internal
     public TableNames tableNames() {
         return config.tableNames();
+    }
+
+    /** Test-only accessor for asserting the version probe picked the right dialect. */
+    @ApiStatus.Internal
+    MysqlDialect dialectForTest() {
+        return dialect;
     }
 }

--- a/grim-internal/src/main/java/ac/grim/grimac/internal/storage/backend/mysql/MysqlBackend.java
+++ b/grim-internal/src/main/java/ac/grim/grimac/internal/storage/backend/mysql/MysqlBackend.java
@@ -41,11 +41,12 @@ import java.util.Set;
 import java.util.UUID;
 
 /**
- * MySQL 8.x backend. Same ring/handler model as the SQLite reference backend —
- * each category's {@link StorageEventHandler} owns a dedicated write connection
- * in {@code autoCommit=false}, reads open a fresh connection per call. No
- * connection pool is bundled; operators who need one can front the JDBC URL
- * with a server-side proxy (ProxySQL) or drop in HikariCP alongside the plugin.
+ * MySQL-family backend. Same ring/handler model as the SQLite reference
+ * backend — each category's {@link StorageEventHandler} owns a dedicated write
+ * connection in {@code autoCommit=false}, reads open a fresh connection per
+ * call. No connection pool is bundled; operators who need one can front the
+ * JDBC URL with a server-side proxy (ProxySQL) or drop in HikariCP alongside
+ * the plugin.
  * <p>
  * Unsupported features gracefully throw {@link UnsupportedOperationException}
  * where the {@link Backend} contract allows it. The schema is the post-v5
@@ -53,6 +54,11 @@ import java.util.UUID;
  * {@code verbose_format} as INTEGER and a {@code metadata} column); there are
  * no pre-v5 MySQL databases to migrate from, so the linear applyVN pattern
  * used by SQLite isn't mirrored here.
+ * <p>
+ * Server flavor (genuine MySQL vs MariaDB) is detected at {@link #init} by
+ * probing {@code SELECT VERSION()}; the dialect that owns the flavor-specific
+ * SQL (functional index vs STORED generated column for {@code current_name},
+ * aliased-row vs legacy {@code VALUES()} upsert) is held in {@link #dialect}.
  */
 @ApiStatus.Internal
 public final class MysqlBackend implements Backend {
@@ -63,9 +69,13 @@ public final class MysqlBackend implements Backend {
     private final Object writeMutex = new Object();
     private final List<BatchingHandler<?>> handlers = new ArrayList<>();
     private final String insertViolations;
-    private final String upsertSessions;
-    private final String upsertIdentities;
-    private final String upsertSettings;
+    // Populated in init() once the dialect is selected from the live engine.
+    // The handlers and direct-write paths read these via final-field-after-init
+    // semantics — init() runs before eventHandlerFor() / writeXxx() is invoked.
+    private String upsertSessions;
+    private String upsertIdentities;
+    private String upsertSettings;
+    private MysqlDialect dialect;
     private Connection writeConn;
     // Cached at init() if minecraft-mysql-jdbc holder is present. When non-null,
     // every openConnection() call routes through the holder's child-first
@@ -76,39 +86,10 @@ public final class MysqlBackend implements Backend {
     public MysqlBackend(MysqlBackendConfig config) {
         this.config = config;
         TableNames t = config.tableNames();
-        // MySQL 8.0+ aliased-row upsert: `... AS new ON DUPLICATE KEY UPDATE col = new.col`.
-        // Avoids the deprecated VALUES(col) reference.
+        // Flavor-agnostic — plain INSERT, no ON DUPLICATE KEY clause.
         this.insertViolations =
                 "INSERT INTO " + t.violations() + "(session_id, player_uuid, check_id, vl, occurred_at, verbose, verbose_format) "
                         + "VALUES (?, ?, ?, ?, ?, ?, ?)";
-        this.upsertSessions =
-                "INSERT INTO " + t.sessions() + "(session_id, player_uuid, server_name, started_at, last_activity, closed_at, "
-                        + "grim_version, client_brand, client_version_pvn, server_version, replay_clips_json) "
-                        + "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?) AS new "
-                        + "ON DUPLICATE KEY UPDATE "
-                        + "server_name=new.server_name, "
-                        + "last_activity=new.last_activity, "
-                        // closed_at: NULL → set transitions only; never overwrite an
-                        // already-closed row with NULL on a late heartbeat.
-                        + "closed_at=COALESCE(" + t.sessions() + ".closed_at, new.closed_at), "
-                        + "grim_version=new.grim_version, "
-                        + "client_brand=new.client_brand, "
-                        + "client_version_pvn=new.client_version_pvn, "
-                        + "server_version=new.server_version, "
-                        + "replay_clips_json=new.replay_clips_json";
-        this.upsertIdentities =
-                "INSERT INTO " + t.players() + "(uuid, current_name, first_seen, last_seen) "
-                        + "VALUES (?, ?, ?, ?) AS new "
-                        + "ON DUPLICATE KEY UPDATE "
-                        + "current_name = new.current_name, "
-                        + "first_seen = LEAST(" + t.players() + ".first_seen, new.first_seen), "
-                        + "last_seen = GREATEST(" + t.players() + ".last_seen, new.last_seen)";
-        this.upsertSettings =
-                "INSERT INTO " + t.settings() + "(scope, scope_key, `key`, value, updated_at) "
-                        + "VALUES (?, ?, ?, ?, ?) AS new "
-                        + "ON DUPLICATE KEY UPDATE "
-                        + "value = new.value, "
-                        + "updated_at = new.updated_at";
     }
 
     @Override public @NotNull String id() { return ID; }
@@ -152,7 +133,12 @@ public final class MysqlBackend implements Backend {
         synchronized (writeMutex) {
             try {
                 this.writeConn = openConnection();
-                MysqlSchema.ensureInitialized(writeConn, "phase1", config.tableNames());
+                this.dialect = new MysqlEightDialect();
+                TableNames t = config.tableNames();
+                this.upsertSessions = dialect.upsertSessions(t);
+                this.upsertIdentities = dialect.upsertIdentities(t);
+                this.upsertSettings = dialect.upsertSettings(t);
+                MysqlSchema.ensureInitialized(writeConn, "phase1", t, dialect);
             } catch (SQLException e) {
                 throw new BackendException("failed to initialise MySQL backend", e);
             }
@@ -555,9 +541,7 @@ public final class MysqlBackend implements Backend {
     }
 
     private Page<PlayerIdentity> getPlayerIdentityByName(Connection c, Queries.GetPlayerIdentityByName q) throws SQLException {
-        try (PreparedStatement ps = c.prepareStatement(
-                "SELECT uuid, current_name, first_seen, last_seen FROM " + config.tableNames().players() + " "
-                        + "WHERE LOWER(current_name) = ? ORDER BY last_seen DESC LIMIT 1")) {
+        try (PreparedStatement ps = c.prepareStatement(dialect.selectIdentityByName(config.tableNames()))) {
             ps.setString(1, q.name().toLowerCase(Locale.ROOT));
             try (ResultSet rs = ps.executeQuery()) {
                 if (rs.next()) return new Page<>(List.of(mapIdentity(rs)), null);
@@ -570,10 +554,7 @@ public final class MysqlBackend implements Backend {
         String prefix = q.lowerPrefix();
         if (prefix == null || prefix.isEmpty() || q.limit() <= 0) return Page.empty();
         String escaped = escapeLike(prefix);
-        try (PreparedStatement ps = c.prepareStatement(
-                "SELECT uuid, current_name, first_seen, last_seen FROM " + config.tableNames().players() + " "
-                        + "WHERE LOWER(current_name) LIKE ? ESCAPE '\\\\' "
-                        + "ORDER BY last_seen DESC LIMIT ?")) {
+        try (PreparedStatement ps = c.prepareStatement(dialect.selectIdentitiesByNamePrefix(config.tableNames()))) {
             ps.setString(1, escaped + "%");
             ps.setInt(2, q.limit());
             try (ResultSet rs = ps.executeQuery()) {

--- a/grim-internal/src/main/java/ac/grim/grimac/internal/storage/backend/mysql/MysqlDialect.java
+++ b/grim-internal/src/main/java/ac/grim/grimac/internal/storage/backend/mysql/MysqlDialect.java
@@ -9,36 +9,106 @@ import java.sql.Statement;
 /**
  * Per-flavor SQL strings and DDL for the MySQL-family backend.
  * <p>
- * Two implementations:
+ * Both impls share identical baseline DDL ({@code current_name_lower} as a
+ * STORED generated column with a plain B-tree index — used to be a flavor
+ * split via MySQL functional indexes vs MariaDB STORED gen cols, but MySQL's
+ * functional-index path didn't actually use the index for prefix LIKE so the
+ * shapes converged on the gen col). Both impls also share identical reads.
+ * The only divergence left is the upsert syntax:
  * <ul>
- *   <li>{@link MysqlEightDialect} — genuine MySQL 8.0+. Uses functional indexes
- *       ({@code INDEX … ((LOWER(col)))}) and the aliased-row upsert form
+ *   <li>{@link MysqlEightDialect} — MySQL 8.0+. Uses the aliased-row upsert
  *       ({@code INSERT … AS new ON DUPLICATE KEY UPDATE col = new.col}, MySQL
- *       8.0.19+).</li>
- *   <li>{@link MariaDbDialect} — MariaDB 10.6+. MariaDB doesn't implement either
- *       of those: the players table carries a {@code STORED} generated column
- *       for the lowercased name with a plain B-tree index on it, and upserts
- *       use the legacy {@code ON DUPLICATE KEY UPDATE col = VALUES(col)} form
- *       (deprecated in MySQL 8.0.20 but never deprecated in MariaDB).</li>
+ *       8.0.19+) which avoids the deprecated {@code VALUES()} reference.</li>
+ *   <li>{@link MariaDbDialect} — MariaDB 10.6+. MariaDB never adopted the
+ *       MySQL 8.0.19 aliased-row form, so it uses the legacy
+ *       {@code … ON DUPLICATE KEY UPDATE col = VALUES(col)} (deprecated in
+ *       MySQL 8.0.20 but never deprecated in MariaDB).</li>
  * </ul>
  * The dialect is selected at {@link MysqlBackend#init} time by probing
  * {@code SELECT VERSION()} — same shape as the SQLite backend's
  * {@link ac.grim.grimac.internal.storage.backend.sqlite.writers.UpserterFactory}
  * version-driven dialect split.
- * <p>
- * Schema migrations ({@link MysqlSchema#ensureInitialized}) are flavor-agnostic
- * — only the v0 baseline DDL needs a flavor split, because the
- * {@code current_name_lower} index storage differs.
  */
 @ApiStatus.Internal
 public interface MysqlDialect {
 
     /**
      * Fresh-database baseline DDL. Creates checks, players, sessions,
-     * violations, settings tables for a brand-new database. The meta
-     * table is created independently in {@link MysqlSchema}.
+     * violations, settings tables for a brand-new database. Identical
+     * across both flavors as of v8 — they share the gen col shape on
+     * the players table. The meta table is created independently in
+     * {@link MysqlSchema}.
      */
-    void applyBaseline(Statement s, TableNames t) throws SQLException;
+    default void applyBaseline(Statement s, TableNames t) throws SQLException {
+        s.executeUpdate("CREATE TABLE " + t.checks() + " ("
+                + "check_id INT AUTO_INCREMENT PRIMARY KEY, "
+                + "stable_key VARCHAR(255) NOT NULL UNIQUE, "
+                + "display VARCHAR(255), "
+                + "description VARCHAR(1024), "
+                + "introduced_version VARCHAR(64), "
+                + "removed_version VARCHAR(64), "
+                + "introduced_at BIGINT"
+                + ") ENGINE=InnoDB DEFAULT CHARSET=utf8mb4");
+
+        // STORED generated column auto-populated on INSERT/UPDATE; the write
+        // path stays narrow (only uuid/current_name/first_seen/last_seen
+        // bound). The plain B-tree index on current_name_lower carries both
+        // exact lookups (WHERE current_name_lower = ?) and prefix range scans
+        // (WHERE current_name_lower LIKE 'x%') on both MySQL 8.x and MariaDB
+        // 10.6+ — verified via EXPLAIN.
+        //
+        // Used to be a MySQL-only functional index ((LOWER(current_name)))
+        // here, but MySQL's optimiser refuses to use functional indexes for
+        // prefix LIKE patterns (only equality is sargable), making
+        // listPlayersByNamePrefix an O(table size) full scan regardless of
+        // selectivity. v7→v8 migration unifies on the gen col shape.
+        s.executeUpdate("CREATE TABLE " + t.players() + " ("
+                + "uuid BINARY(16) PRIMARY KEY, "
+                + "current_name VARCHAR(32), "
+                + "current_name_lower VARCHAR(32) AS (LOWER(current_name)) STORED, "
+                + "first_seen BIGINT NOT NULL, "
+                + "last_seen BIGINT NOT NULL, "
+                + "INDEX idx_" + t.players() + "_name_lower (current_name_lower)"
+                + ") ENGINE=InnoDB DEFAULT CHARSET=utf8mb4");
+
+        s.executeUpdate("CREATE TABLE " + t.sessions() + " ("
+                + "session_id BINARY(16) PRIMARY KEY, "
+                + "player_uuid BINARY(16) NOT NULL, "
+                + "server_name VARCHAR(64), "
+                + "started_at BIGINT NOT NULL, "
+                + "last_activity BIGINT NOT NULL, "
+                + "closed_at BIGINT NULL, "
+                + "grim_version VARCHAR(64), "
+                + "client_brand VARCHAR(64), "
+                + "client_version_pvn INT NOT NULL DEFAULT -1, "
+                + "server_version VARCHAR(64), "
+                + "replay_clips_json MEDIUMTEXT, "
+                + "INDEX idx_" + t.sessions() + "_player_started (player_uuid, started_at DESC)"
+                + ") ENGINE=InnoDB DEFAULT CHARSET=utf8mb4");
+
+        s.executeUpdate("CREATE TABLE " + t.violations() + " ("
+                + "id BIGINT AUTO_INCREMENT PRIMARY KEY, "
+                + "session_id BINARY(16) NOT NULL, "
+                + "player_uuid BINARY(16) NOT NULL, "
+                + "check_id INT NOT NULL, "
+                + "vl DOUBLE NOT NULL, "
+                + "occurred_at BIGINT NOT NULL, "
+                + "verbose MEDIUMTEXT, "
+                + "verbose_format INT NOT NULL DEFAULT 0, "
+                + "metadata MEDIUMTEXT, "
+                + "INDEX idx_" + t.violations() + "_session_time (session_id, occurred_at), "
+                + "INDEX idx_" + t.violations() + "_player (player_uuid)"
+                + ") ENGINE=InnoDB DEFAULT CHARSET=utf8mb4");
+
+        s.executeUpdate("CREATE TABLE " + t.settings() + " ("
+                + "scope VARCHAR(16) NOT NULL, "
+                + "scope_key VARCHAR(128) NOT NULL, "
+                + "`key` VARCHAR(128) NOT NULL, "
+                + "value LONGBLOB NOT NULL, "
+                + "updated_at BIGINT NOT NULL, "
+                + "PRIMARY KEY (scope, scope_key, `key`)"
+                + ") ENGINE=InnoDB DEFAULT CHARSET=utf8mb4");
+    }
 
     String upsertSessions(TableNames t);
 
@@ -47,8 +117,29 @@ public interface MysqlDialect {
     String upsertSettings(TableNames t);
 
     /** Single-row case-insensitive name lookup, latest {@code last_seen} first. */
-    String selectIdentityByName(TableNames t);
+    default String selectIdentityByName(TableNames t) {
+        return "SELECT uuid, current_name, first_seen, last_seen FROM " + t.players() + " "
+                + "WHERE current_name_lower = ? ORDER BY last_seen DESC LIMIT 1";
+    }
 
     /** Case-insensitive prefix lookup for the player-name autocomplete query. */
-    String selectIdentitiesByNamePrefix(TableNames t);
+    default String selectIdentitiesByNamePrefix(TableNames t) {
+        return "SELECT uuid, current_name, first_seen, last_seen FROM " + t.players() + " "
+                + "WHERE current_name_lower LIKE ? ESCAPE '\\\\' "
+                + "ORDER BY last_seen DESC LIMIT ?";
+    }
+
+    /**
+     * v7 → v8 migration step. v7 was the last shape that had a flavor split
+     * on the players table — MySQL used a functional index on
+     * {@code LOWER(current_name)}, MariaDB used a STORED generated
+     * {@code current_name_lower} column. v8 unifies on the MariaDB shape.
+     * <p>
+     * Default no-op: MariaDB v7 deployments already had the v8 column
+     * layout (its dialect was always at this shape), so this hook only
+     * needs work for MySQL — see {@link MysqlEightDialect}'s override.
+     */
+    default void migrateV7ToV8(Statement s, TableNames t) throws SQLException {
+        // no-op
+    }
 }

--- a/grim-internal/src/main/java/ac/grim/grimac/internal/storage/backend/mysql/MysqlDialect.java
+++ b/grim-internal/src/main/java/ac/grim/grimac/internal/storage/backend/mysql/MysqlDialect.java
@@ -1,0 +1,54 @@
+package ac.grim.grimac.internal.storage.backend.mysql;
+
+import ac.grim.grimac.api.storage.config.TableNames;
+import org.jetbrains.annotations.ApiStatus;
+
+import java.sql.SQLException;
+import java.sql.Statement;
+
+/**
+ * Per-flavor SQL strings and DDL for the MySQL-family backend.
+ * <p>
+ * Two implementations:
+ * <ul>
+ *   <li>{@link MysqlEightDialect} — genuine MySQL 8.0+. Uses functional indexes
+ *       ({@code INDEX … ((LOWER(col)))}) and the aliased-row upsert form
+ *       ({@code INSERT … AS new ON DUPLICATE KEY UPDATE col = new.col}, MySQL
+ *       8.0.19+).</li>
+ *   <li>{@link MariaDbDialect} — MariaDB 10.6+. MariaDB doesn't implement either
+ *       of those: the players table carries a {@code STORED} generated column
+ *       for the lowercased name with a plain B-tree index on it, and upserts
+ *       use the legacy {@code ON DUPLICATE KEY UPDATE col = VALUES(col)} form
+ *       (deprecated in MySQL 8.0.20 but never deprecated in MariaDB).</li>
+ * </ul>
+ * The dialect is selected at {@link MysqlBackend#init} time by probing
+ * {@code SELECT VERSION()} — same shape as the SQLite backend's
+ * {@link ac.grim.grimac.internal.storage.backend.sqlite.writers.UpserterFactory}
+ * version-driven dialect split.
+ * <p>
+ * Schema migrations ({@link MysqlSchema#ensureInitialized}) are flavor-agnostic
+ * — only the v0 baseline DDL needs a flavor split, because the
+ * {@code current_name_lower} index storage differs.
+ */
+@ApiStatus.Internal
+public interface MysqlDialect {
+
+    /**
+     * Fresh-database baseline DDL. Creates checks, players, sessions,
+     * violations, settings tables for a brand-new database. The meta
+     * table is created independently in {@link MysqlSchema}.
+     */
+    void applyBaseline(Statement s, TableNames t) throws SQLException;
+
+    String upsertSessions(TableNames t);
+
+    String upsertIdentities(TableNames t);
+
+    String upsertSettings(TableNames t);
+
+    /** Single-row case-insensitive name lookup, latest {@code last_seen} first. */
+    String selectIdentityByName(TableNames t);
+
+    /** Case-insensitive prefix lookup for the player-name autocomplete query. */
+    String selectIdentitiesByNamePrefix(TableNames t);
+}

--- a/grim-internal/src/main/java/ac/grim/grimac/internal/storage/backend/mysql/MysqlEightDialect.java
+++ b/grim-internal/src/main/java/ac/grim/grimac/internal/storage/backend/mysql/MysqlEightDialect.java
@@ -7,80 +7,18 @@ import java.sql.SQLException;
 import java.sql.Statement;
 
 /**
- * MySQL 8.0+ dialect. Uses the functional index
- * ({@code INDEX … ((LOWER(current_name)))}) introduced in MySQL 8.0.13 and the
- * aliased-row upsert form ({@code … AS new ON DUPLICATE KEY UPDATE col = new.col})
- * introduced in MySQL 8.0.19.
+ * MySQL 8.0+ dialect. Inherits the v8 baseline DDL and read SQL from
+ * {@link MysqlDialect}; the only divergence from {@link MariaDbDialect} is
+ * the upsert syntax, which uses MySQL 8.0.19's aliased-row form
+ * ({@code … AS new ON DUPLICATE KEY UPDATE col = new.col}) to avoid the
+ * deprecated {@code VALUES()} reference.
  * <p>
- * The minimum effective MySQL version is therefore 8.0.19 — the
- * {@link MysqlBackend} version probe doesn't enforce that explicitly because
- * pre-8.0.19 MySQL is older than the connector-j we ship and effectively
- * extinct in production.
+ * The minimum effective MySQL version is 8.0.19 — pre-8.0.19 MySQL is older
+ * than the connector-j we ship and effectively extinct in production, so the
+ * version probe in {@link MysqlBackend} doesn't enforce that explicitly.
  */
 @ApiStatus.Internal
 final class MysqlEightDialect implements MysqlDialect {
-
-    @Override
-    public void applyBaseline(Statement s, TableNames t) throws SQLException {
-        s.executeUpdate("CREATE TABLE " + t.checks() + " ("
-                + "check_id INT AUTO_INCREMENT PRIMARY KEY, "
-                + "stable_key VARCHAR(255) NOT NULL UNIQUE, "
-                + "display VARCHAR(255), "
-                + "description VARCHAR(1024), "
-                + "introduced_version VARCHAR(64), "
-                + "removed_version VARCHAR(64), "
-                + "introduced_at BIGINT"
-                + ") ENGINE=InnoDB DEFAULT CHARSET=utf8mb4");
-
-        // Functional index — MySQL 8.0.13+. Lookups via WHERE LOWER(current_name)
-        // = ? are rewritten by the optimiser to use this index directly; no
-        // generated column needed.
-        s.executeUpdate("CREATE TABLE " + t.players() + " ("
-                + "uuid BINARY(16) PRIMARY KEY, "
-                + "current_name VARCHAR(32), "
-                + "first_seen BIGINT NOT NULL, "
-                + "last_seen BIGINT NOT NULL, "
-                + "INDEX idx_" + t.players() + "_name_lower ((LOWER(current_name)))"
-                + ") ENGINE=InnoDB DEFAULT CHARSET=utf8mb4");
-
-        s.executeUpdate("CREATE TABLE " + t.sessions() + " ("
-                + "session_id BINARY(16) PRIMARY KEY, "
-                + "player_uuid BINARY(16) NOT NULL, "
-                + "server_name VARCHAR(64), "
-                + "started_at BIGINT NOT NULL, "
-                + "last_activity BIGINT NOT NULL, "
-                + "closed_at BIGINT NULL, "
-                + "grim_version VARCHAR(64), "
-                + "client_brand VARCHAR(64), "
-                + "client_version_pvn INT NOT NULL DEFAULT -1, "
-                + "server_version VARCHAR(64), "
-                + "replay_clips_json MEDIUMTEXT, "
-                + "INDEX idx_" + t.sessions() + "_player_started (player_uuid, started_at DESC)"
-                + ") ENGINE=InnoDB DEFAULT CHARSET=utf8mb4");
-
-        s.executeUpdate("CREATE TABLE " + t.violations() + " ("
-                + "id BIGINT AUTO_INCREMENT PRIMARY KEY, "
-                + "session_id BINARY(16) NOT NULL, "
-                + "player_uuid BINARY(16) NOT NULL, "
-                + "check_id INT NOT NULL, "
-                + "vl DOUBLE NOT NULL, "
-                + "occurred_at BIGINT NOT NULL, "
-                + "verbose MEDIUMTEXT, "
-                + "verbose_format INT NOT NULL DEFAULT 0, "
-                + "metadata MEDIUMTEXT, "
-                + "INDEX idx_" + t.violations() + "_session_time (session_id, occurred_at), "
-                + "INDEX idx_" + t.violations() + "_player (player_uuid)"
-                + ") ENGINE=InnoDB DEFAULT CHARSET=utf8mb4");
-
-        s.executeUpdate("CREATE TABLE " + t.settings() + " ("
-                + "scope VARCHAR(16) NOT NULL, "
-                + "scope_key VARCHAR(128) NOT NULL, "
-                + "`key` VARCHAR(128) NOT NULL, "
-                + "value LONGBLOB NOT NULL, "
-                + "updated_at BIGINT NOT NULL, "
-                + "PRIMARY KEY (scope, scope_key, `key`)"
-                + ") ENGINE=InnoDB DEFAULT CHARSET=utf8mb4");
-    }
 
     @Override
     public String upsertSessions(TableNames t) {
@@ -119,16 +57,30 @@ final class MysqlEightDialect implements MysqlDialect {
                 + "updated_at = new.updated_at";
     }
 
+    /**
+     * v7 → v8 migration on MySQL: replace the functional-index shape with
+     * the gen col shape so {@code listPlayersByNamePrefix} actually uses
+     * an index. MySQL 8 doesn't support {@code ALGORITHM=INSTANT} or
+     * {@code INPLACE} for adding STORED generated columns — falls back to
+     * {@code ALGORITHM=COPY}, which rewrites the table and blocks writes
+     * for the duration. Acceptable on alpha-only v7 tables; for any
+     * future post-GA migration, an external online tool
+     * (gh-ost / pt-online-schema-change) would be the move.
+     * <p>
+     * The DROP+ADD INDEX is one ALTER so the table never has zero
+     * lower-case-name index between the two operations. ANALYZE TABLE
+     * is run last so the optimiser sees fresh stats on the new index.
+     */
     @Override
-    public String selectIdentityByName(TableNames t) {
-        return "SELECT uuid, current_name, first_seen, last_seen FROM " + t.players() + " "
-                + "WHERE LOWER(current_name) = ? ORDER BY last_seen DESC LIMIT 1";
-    }
-
-    @Override
-    public String selectIdentitiesByNamePrefix(TableNames t) {
-        return "SELECT uuid, current_name, first_seen, last_seen FROM " + t.players() + " "
-                + "WHERE LOWER(current_name) LIKE ? ESCAPE '\\\\' "
-                + "ORDER BY last_seen DESC LIMIT ?";
+    public void migrateV7ToV8(Statement s, TableNames t) throws SQLException {
+        s.executeUpdate("ALTER TABLE " + t.players()
+                + " ADD COLUMN current_name_lower VARCHAR(32) AS (LOWER(current_name)) STORED");
+        s.executeUpdate("ALTER TABLE " + t.players()
+                + " DROP INDEX idx_" + t.players() + "_name_lower"
+                + ", ADD INDEX idx_" + t.players() + "_name_lower (current_name_lower)");
+        // ANALYZE TABLE returns a one-row result set (Op/Msg_type/Msg_text)
+        // rather than an update count, so executeUpdate() rejects it. Use
+        // execute() and discard the resultset cursor.
+        s.execute("ANALYZE TABLE " + t.players());
     }
 }

--- a/grim-internal/src/main/java/ac/grim/grimac/internal/storage/backend/mysql/MysqlEightDialect.java
+++ b/grim-internal/src/main/java/ac/grim/grimac/internal/storage/backend/mysql/MysqlEightDialect.java
@@ -1,0 +1,134 @@
+package ac.grim.grimac.internal.storage.backend.mysql;
+
+import ac.grim.grimac.api.storage.config.TableNames;
+import org.jetbrains.annotations.ApiStatus;
+
+import java.sql.SQLException;
+import java.sql.Statement;
+
+/**
+ * MySQL 8.0+ dialect. Uses the functional index
+ * ({@code INDEX … ((LOWER(current_name)))}) introduced in MySQL 8.0.13 and the
+ * aliased-row upsert form ({@code … AS new ON DUPLICATE KEY UPDATE col = new.col})
+ * introduced in MySQL 8.0.19.
+ * <p>
+ * The minimum effective MySQL version is therefore 8.0.19 — the
+ * {@link MysqlBackend} version probe doesn't enforce that explicitly because
+ * pre-8.0.19 MySQL is older than the connector-j we ship and effectively
+ * extinct in production.
+ */
+@ApiStatus.Internal
+final class MysqlEightDialect implements MysqlDialect {
+
+    @Override
+    public void applyBaseline(Statement s, TableNames t) throws SQLException {
+        s.executeUpdate("CREATE TABLE " + t.checks() + " ("
+                + "check_id INT AUTO_INCREMENT PRIMARY KEY, "
+                + "stable_key VARCHAR(255) NOT NULL UNIQUE, "
+                + "display VARCHAR(255), "
+                + "description VARCHAR(1024), "
+                + "introduced_version VARCHAR(64), "
+                + "removed_version VARCHAR(64), "
+                + "introduced_at BIGINT"
+                + ") ENGINE=InnoDB DEFAULT CHARSET=utf8mb4");
+
+        // Functional index — MySQL 8.0.13+. Lookups via WHERE LOWER(current_name)
+        // = ? are rewritten by the optimiser to use this index directly; no
+        // generated column needed.
+        s.executeUpdate("CREATE TABLE " + t.players() + " ("
+                + "uuid BINARY(16) PRIMARY KEY, "
+                + "current_name VARCHAR(32), "
+                + "first_seen BIGINT NOT NULL, "
+                + "last_seen BIGINT NOT NULL, "
+                + "INDEX idx_" + t.players() + "_name_lower ((LOWER(current_name)))"
+                + ") ENGINE=InnoDB DEFAULT CHARSET=utf8mb4");
+
+        s.executeUpdate("CREATE TABLE " + t.sessions() + " ("
+                + "session_id BINARY(16) PRIMARY KEY, "
+                + "player_uuid BINARY(16) NOT NULL, "
+                + "server_name VARCHAR(64), "
+                + "started_at BIGINT NOT NULL, "
+                + "last_activity BIGINT NOT NULL, "
+                + "closed_at BIGINT NULL, "
+                + "grim_version VARCHAR(64), "
+                + "client_brand VARCHAR(64), "
+                + "client_version_pvn INT NOT NULL DEFAULT -1, "
+                + "server_version VARCHAR(64), "
+                + "replay_clips_json MEDIUMTEXT, "
+                + "INDEX idx_" + t.sessions() + "_player_started (player_uuid, started_at DESC)"
+                + ") ENGINE=InnoDB DEFAULT CHARSET=utf8mb4");
+
+        s.executeUpdate("CREATE TABLE " + t.violations() + " ("
+                + "id BIGINT AUTO_INCREMENT PRIMARY KEY, "
+                + "session_id BINARY(16) NOT NULL, "
+                + "player_uuid BINARY(16) NOT NULL, "
+                + "check_id INT NOT NULL, "
+                + "vl DOUBLE NOT NULL, "
+                + "occurred_at BIGINT NOT NULL, "
+                + "verbose MEDIUMTEXT, "
+                + "verbose_format INT NOT NULL DEFAULT 0, "
+                + "metadata MEDIUMTEXT, "
+                + "INDEX idx_" + t.violations() + "_session_time (session_id, occurred_at), "
+                + "INDEX idx_" + t.violations() + "_player (player_uuid)"
+                + ") ENGINE=InnoDB DEFAULT CHARSET=utf8mb4");
+
+        s.executeUpdate("CREATE TABLE " + t.settings() + " ("
+                + "scope VARCHAR(16) NOT NULL, "
+                + "scope_key VARCHAR(128) NOT NULL, "
+                + "`key` VARCHAR(128) NOT NULL, "
+                + "value LONGBLOB NOT NULL, "
+                + "updated_at BIGINT NOT NULL, "
+                + "PRIMARY KEY (scope, scope_key, `key`)"
+                + ") ENGINE=InnoDB DEFAULT CHARSET=utf8mb4");
+    }
+
+    @Override
+    public String upsertSessions(TableNames t) {
+        return "INSERT INTO " + t.sessions() + "(session_id, player_uuid, server_name, started_at, last_activity, closed_at, "
+                + "grim_version, client_brand, client_version_pvn, server_version, replay_clips_json) "
+                + "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?) AS new "
+                + "ON DUPLICATE KEY UPDATE "
+                + "server_name=new.server_name, "
+                + "last_activity=new.last_activity, "
+                // closed_at: NULL → set transitions only; never overwrite an
+                // already-closed row with NULL on a late heartbeat.
+                + "closed_at=COALESCE(" + t.sessions() + ".closed_at, new.closed_at), "
+                + "grim_version=new.grim_version, "
+                + "client_brand=new.client_brand, "
+                + "client_version_pvn=new.client_version_pvn, "
+                + "server_version=new.server_version, "
+                + "replay_clips_json=new.replay_clips_json";
+    }
+
+    @Override
+    public String upsertIdentities(TableNames t) {
+        return "INSERT INTO " + t.players() + "(uuid, current_name, first_seen, last_seen) "
+                + "VALUES (?, ?, ?, ?) AS new "
+                + "ON DUPLICATE KEY UPDATE "
+                + "current_name = new.current_name, "
+                + "first_seen = LEAST(" + t.players() + ".first_seen, new.first_seen), "
+                + "last_seen = GREATEST(" + t.players() + ".last_seen, new.last_seen)";
+    }
+
+    @Override
+    public String upsertSettings(TableNames t) {
+        return "INSERT INTO " + t.settings() + "(scope, scope_key, `key`, value, updated_at) "
+                + "VALUES (?, ?, ?, ?, ?) AS new "
+                + "ON DUPLICATE KEY UPDATE "
+                + "value = new.value, "
+                + "updated_at = new.updated_at";
+    }
+
+    @Override
+    public String selectIdentityByName(TableNames t) {
+        return "SELECT uuid, current_name, first_seen, last_seen FROM " + t.players() + " "
+                + "WHERE LOWER(current_name) = ? ORDER BY last_seen DESC LIMIT 1";
+    }
+
+    @Override
+    public String selectIdentitiesByNamePrefix(TableNames t) {
+        return "SELECT uuid, current_name, first_seen, last_seen FROM " + t.players() + " "
+                + "WHERE LOWER(current_name) LIKE ? ESCAPE '\\\\' "
+                + "ORDER BY last_seen DESC LIMIT ?";
+    }
+}

--- a/grim-internal/src/main/java/ac/grim/grimac/internal/storage/backend/mysql/MysqlSchema.java
+++ b/grim-internal/src/main/java/ac/grim/grimac/internal/storage/backend/mysql/MysqlSchema.java
@@ -12,11 +12,17 @@ import java.sql.Statement;
 import java.util.Map;
 
 /**
- * MySQL 8.x schema for the MySQL backend. New backends are born at the
+ * MySQL-family schema for the MySQL backend. New backends are born at the
  * {@link #CURRENT_VERSION} baseline (the shape SQLite reached at v5) rather
  * than replaying each migration — there are no pre-v5 MySQL databases to
  * upgrade from, so the linear applyVN pattern used by SQLite is overkill
  * here. Future bumps will add applyVN methods as normal.
+ * <p>
+ * The v0 baseline DDL is delegated to the {@link MysqlDialect} the
+ * {@link MysqlBackend} probed at init — only the players table differs
+ * between MySQL 8 (functional index) and MariaDB 10.6+ (STORED generated
+ * column + plain index). Forward migrations are flavor-agnostic and stay
+ * inline here.
  */
 @ApiStatus.Internal
 public final class MysqlSchema {
@@ -25,7 +31,7 @@ public final class MysqlSchema {
 
     private MysqlSchema() {}
 
-    public static void ensureInitialized(Connection c, String grimCoreVersion, TableNames t) throws SQLException {
+    public static void ensureInitialized(Connection c, String grimCoreVersion, TableNames t, MysqlDialect dialect) throws SQLException {
         try (Statement s = c.createStatement()) {
             // MySQL check-constraint names are schema-global (not table-scoped),
             // so the name must be unique per meta table in the DB — otherwise two
@@ -43,7 +49,7 @@ public final class MysqlSchema {
 
         int existing = readSchemaVersion(c, t);
         if (existing < 0) {
-            applyBaseline(c, t);
+            applyBaseline(c, t, dialect);
             long now = System.currentTimeMillis();
             try (PreparedStatement ps = c.prepareStatement(
                     "INSERT INTO " + t.meta() + "(id, schema_version, grim_core_version, initialized_at, last_migration_at) "
@@ -110,63 +116,9 @@ public final class MysqlSchema {
         }
     }
 
-    private static void applyBaseline(Connection c, TableNames t) throws SQLException {
+    private static void applyBaseline(Connection c, TableNames t, MysqlDialect dialect) throws SQLException {
         try (Statement s = c.createStatement()) {
-            s.executeUpdate("CREATE TABLE " + t.checks() + " ("
-                    + "check_id INT AUTO_INCREMENT PRIMARY KEY, "
-                    + "stable_key VARCHAR(255) NOT NULL UNIQUE, "
-                    + "display VARCHAR(255), "
-                    + "description VARCHAR(1024), "
-                    + "introduced_version VARCHAR(64), "
-                    + "removed_version VARCHAR(64), "
-                    + "introduced_at BIGINT"
-                    + ") ENGINE=InnoDB DEFAULT CHARSET=utf8mb4");
-
-            s.executeUpdate("CREATE TABLE " + t.players() + " ("
-                    + "uuid BINARY(16) PRIMARY KEY, "
-                    + "current_name VARCHAR(32), "
-                    + "first_seen BIGINT NOT NULL, "
-                    + "last_seen BIGINT NOT NULL, "
-                    + "INDEX idx_" + t.players() + "_name_lower ((LOWER(current_name)))"
-                    + ") ENGINE=InnoDB DEFAULT CHARSET=utf8mb4");
-
-            s.executeUpdate("CREATE TABLE " + t.sessions() + " ("
-                    + "session_id BINARY(16) PRIMARY KEY, "
-                    + "player_uuid BINARY(16) NOT NULL, "
-                    + "server_name VARCHAR(64), "
-                    + "started_at BIGINT NOT NULL, "
-                    + "last_activity BIGINT NOT NULL, "
-                    + "closed_at BIGINT NULL, "
-                    + "grim_version VARCHAR(64), "
-                    + "client_brand VARCHAR(64), "
-                    + "client_version_pvn INT NOT NULL DEFAULT -1, "
-                    + "server_version VARCHAR(64), "
-                    + "replay_clips_json MEDIUMTEXT, "
-                    + "INDEX idx_" + t.sessions() + "_player_started (player_uuid, started_at DESC)"
-                    + ") ENGINE=InnoDB DEFAULT CHARSET=utf8mb4");
-
-            s.executeUpdate("CREATE TABLE " + t.violations() + " ("
-                    + "id BIGINT AUTO_INCREMENT PRIMARY KEY, "
-                    + "session_id BINARY(16) NOT NULL, "
-                    + "player_uuid BINARY(16) NOT NULL, "
-                    + "check_id INT NOT NULL, "
-                    + "vl DOUBLE NOT NULL, "
-                    + "occurred_at BIGINT NOT NULL, "
-                    + "verbose MEDIUMTEXT, "
-                    + "verbose_format INT NOT NULL DEFAULT 0, "
-                    + "metadata MEDIUMTEXT, "
-                    + "INDEX idx_" + t.violations() + "_session_time (session_id, occurred_at), "
-                    + "INDEX idx_" + t.violations() + "_player (player_uuid)"
-                    + ") ENGINE=InnoDB DEFAULT CHARSET=utf8mb4");
-
-            s.executeUpdate("CREATE TABLE " + t.settings() + " ("
-                    + "scope VARCHAR(16) NOT NULL, "
-                    + "scope_key VARCHAR(128) NOT NULL, "
-                    + "`key` VARCHAR(128) NOT NULL, "
-                    + "value LONGBLOB NOT NULL, "
-                    + "updated_at BIGINT NOT NULL, "
-                    + "PRIMARY KEY (scope, scope_key, `key`)"
-                    + ") ENGINE=InnoDB DEFAULT CHARSET=utf8mb4");
+            dialect.applyBaseline(s, t);
         }
     }
 }

--- a/grim-internal/src/main/java/ac/grim/grimac/internal/storage/backend/mysql/MysqlSchema.java
+++ b/grim-internal/src/main/java/ac/grim/grimac/internal/storage/backend/mysql/MysqlSchema.java
@@ -16,18 +16,20 @@ import java.util.Map;
  * {@link #CURRENT_VERSION} baseline (the shape SQLite reached at v5) rather
  * than replaying each migration — there are no pre-v5 MySQL databases to
  * upgrade from, so the linear applyVN pattern used by SQLite is overkill
- * here. Future bumps will add applyVN methods as normal.
+ * for the v0 → v5 range. Per-version forward migrations land here.
  * <p>
- * The v0 baseline DDL is delegated to the {@link MysqlDialect} the
- * {@link MysqlBackend} probed at init — only the players table differs
- * between MySQL 8 (functional index) and MariaDB 10.6+ (STORED generated
- * column + plain index). Forward migrations are flavor-agnostic and stay
- * inline here.
+ * Baseline DDL and per-version migrations may be delegated to the
+ * {@link MysqlDialect} the {@link MysqlBackend} probed at init when the
+ * change is flavor-specific — currently {@code applyBaseline} (formerly
+ * different between MySQL functional indexes and MariaDB STORED gen cols;
+ * unified at v8 onto the gen col shape) and {@code migrateV7ToV8} (the
+ * MySQL-side ALTER that brings v7 deployments onto the v8 shape; no-op on
+ * MariaDB whose v7 schema already matched).
  */
 @ApiStatus.Internal
 public final class MysqlSchema {
 
-    public static final int CURRENT_VERSION = 7;
+    public static final int CURRENT_VERSION = 8;
 
     private MysqlSchema() {}
 
@@ -72,6 +74,7 @@ public final class MysqlSchema {
         // Forward migrations — additive only.
         if (existing < 6) migrateV5ToV6(c, t);
         if (existing < 7) migrateV6ToV7(c, t);
+        if (existing < 8) migrateV7ToV8(c, t, dialect);
 
         if (existing < CURRENT_VERSION) {
             try (PreparedStatement ps = c.prepareStatement(
@@ -113,6 +116,22 @@ public final class MysqlSchema {
             // MySQL "Table 'foo.bar' doesn't exist" — error code 1146
             if (msg.contains("doesn't exist") || e.getErrorCode() == 1146) return -1;
             throw e;
+        }
+    }
+
+    /**
+     * v7 → v8: unify the players table on {@code current_name_lower} as a
+     * STORED generated column with a plain B-tree index. v7 had a flavor
+     * split — MySQL used a functional index, MariaDB used the gen col
+     * shape — but MySQL's optimiser refused to use the functional index
+     * for prefix LIKE patterns, leaving {@code listPlayersByNamePrefix}
+     * on MySQL as an O(table-size) full scan. Delegated to the dialect
+     * because only the MySQL path needs ALTER work; on MariaDB this is
+     * a no-op (its v7 schema already matched the v8 shape).
+     */
+    private static void migrateV7ToV8(Connection c, TableNames t, MysqlDialect dialect) throws SQLException {
+        try (Statement s = c.createStatement()) {
+            dialect.migrateV7ToV8(s, t);
         }
     }
 

--- a/grim-internal/src/test/java/ac/grim/grimac/internal/storage/backend/mysql/MysqlBackendDialectTest.java
+++ b/grim-internal/src/test/java/ac/grim/grimac/internal/storage/backend/mysql/MysqlBackendDialectTest.java
@@ -26,6 +26,7 @@ import org.junit.jupiter.params.provider.EnumSource;
 import java.nio.file.Path;
 import java.sql.Connection;
 import java.sql.DriverManager;
+import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
 import java.util.Locale;
@@ -82,8 +83,8 @@ class MysqlBackendDialectTest {
         assumeTrue(reachable(flavor), () ->
                 "Skipping; " + flavor.label + " fixture not reachable on 127.0.0.1:" + flavor.port);
 
-        // Fresh DB so applyBaseline runs (the migrations path is exercised by a
-        // separate test that pre-seeds an old version row — out of scope here).
+        // Fresh DB so applyBaseline runs the v8 baseline. Migration path is
+        // exercised separately in v7ToV8Migration() below.
         try (Connection admin = DriverManager.getConnection(flavor.adminUrl(), "root", flavor.rootPassword);
              Statement s = admin.createStatement()) {
             s.executeUpdate("DROP DATABASE IF EXISTS grim");
@@ -176,6 +177,132 @@ class MysqlBackendDialectTest {
                     new Queries.ListViolationsInSession(session, 2, null));
             assertEquals(2, first.items().size(), "page 1 size");
             assertNotNull(first.nextCursor(), "page 1 has cursor");
+        } finally {
+            try { b.close(); } catch (BackendException ignore) {}
+        }
+    }
+
+    /**
+     * Pre-seeds a v7-shape MySQL database (functional index, no
+     * {@code current_name_lower} column, schema_version=7), then boots
+     * MysqlBackend and verifies the v7→v8 migration ran: the gen col exists
+     * and is auto-populated, the new plain index is in place, the old
+     * functional index is gone, schema_version is 8, and read queries
+     * still work end-to-end.
+     * <p>
+     * MariaDB-only: skipped on MariaDB because no v7 MariaDB schema ever
+     * existed (the dialect failed to initialise pre-this-PR; new MariaDB
+     * deployments are born at v8 directly via the unified baseline).
+     */
+    @org.junit.jupiter.api.Test
+    @DisplayName("MySQL v7→v8 migration — gen col + index swap on existing database")
+    void v7ToV8Migration(@TempDir Path tempDir) throws Exception {
+        Flavor flavor = Flavor.MYSQL;
+        assumeTrue(reachable(flavor), "Skipping; mysql fixture not reachable");
+
+        // Reset DB and pre-seed the v7 shape: functional index on
+        // LOWER(current_name), no current_name_lower column, schema_version=7
+        // in the meta table. Mirrors what an alpha v1.3.2.0 MySQL deployment
+        // would look like before this PR landed.
+        try (Connection admin = DriverManager.getConnection(flavor.adminUrl(), "root", flavor.rootPassword);
+             Statement s = admin.createStatement()) {
+            s.executeUpdate("DROP DATABASE IF EXISTS grim");
+            s.executeUpdate("CREATE DATABASE grim CHARACTER SET utf8mb4");
+            s.executeUpdate("USE grim");
+            s.executeUpdate("CREATE TABLE grim_meta ("
+                    + "id TINYINT PRIMARY KEY, schema_version INT NOT NULL, "
+                    + "grim_core_version VARCHAR(64), initialized_at BIGINT NOT NULL, "
+                    + "last_migration_at BIGINT NOT NULL, "
+                    + "CONSTRAINT grim_meta_singleton CHECK (id = 0)"
+                    + ") ENGINE=InnoDB DEFAULT CHARSET=utf8mb4");
+            s.executeUpdate("CREATE TABLE grim_checks ("
+                    + "check_id INT AUTO_INCREMENT PRIMARY KEY, "
+                    + "stable_key VARCHAR(255) NOT NULL UNIQUE, "
+                    + "display VARCHAR(255), description VARCHAR(1024), "
+                    + "introduced_version VARCHAR(64), removed_version VARCHAR(64), "
+                    + "introduced_at BIGINT) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4");
+            // The v7 players-table shape: functional idx, no gen col.
+            s.executeUpdate("CREATE TABLE grim_players ("
+                    + "uuid BINARY(16) PRIMARY KEY, current_name VARCHAR(32), "
+                    + "first_seen BIGINT NOT NULL, last_seen BIGINT NOT NULL, "
+                    + "INDEX idx_grim_players_name_lower ((LOWER(current_name)))"
+                    + ") ENGINE=InnoDB DEFAULT CHARSET=utf8mb4");
+            s.executeUpdate("CREATE TABLE grim_sessions ("
+                    + "session_id BINARY(16) PRIMARY KEY, player_uuid BINARY(16) NOT NULL, "
+                    + "server_name VARCHAR(64), started_at BIGINT NOT NULL, "
+                    + "last_activity BIGINT NOT NULL, closed_at BIGINT NULL, "
+                    + "grim_version VARCHAR(64), client_brand VARCHAR(64), "
+                    + "client_version_pvn INT NOT NULL DEFAULT -1, "
+                    + "server_version VARCHAR(64), replay_clips_json MEDIUMTEXT, "
+                    + "INDEX idx_grim_sessions_player_started (player_uuid, started_at DESC)"
+                    + ") ENGINE=InnoDB DEFAULT CHARSET=utf8mb4");
+            s.executeUpdate("CREATE TABLE grim_violations ("
+                    + "id BIGINT AUTO_INCREMENT PRIMARY KEY, session_id BINARY(16) NOT NULL, "
+                    + "player_uuid BINARY(16) NOT NULL, check_id INT NOT NULL, "
+                    + "vl DOUBLE NOT NULL, occurred_at BIGINT NOT NULL, "
+                    + "verbose MEDIUMTEXT, verbose_format INT NOT NULL DEFAULT 0, "
+                    + "metadata MEDIUMTEXT, "
+                    + "INDEX idx_grim_violations_session_time (session_id, occurred_at), "
+                    + "INDEX idx_grim_violations_player (player_uuid)"
+                    + ") ENGINE=InnoDB DEFAULT CHARSET=utf8mb4");
+            s.executeUpdate("CREATE TABLE grim_settings ("
+                    + "scope VARCHAR(16) NOT NULL, scope_key VARCHAR(128) NOT NULL, "
+                    + "`key` VARCHAR(128) NOT NULL, value LONGBLOB NOT NULL, "
+                    + "updated_at BIGINT NOT NULL, "
+                    + "PRIMARY KEY (scope, scope_key, `key`)"
+                    + ") ENGINE=InnoDB DEFAULT CHARSET=utf8mb4");
+            s.executeUpdate("INSERT INTO grim_meta (id, schema_version, grim_core_version, initialized_at, last_migration_at) "
+                    + "VALUES (0, 7, 'v7-seed', 1, 1)");
+            // Seed an identity row so we can verify the gen col gets backfilled.
+            s.executeUpdate("INSERT INTO grim_players (uuid, current_name, first_seen, last_seen) "
+                    + "VALUES (UNHEX('0000000000000000000000000000007F'), 'CamelCaseName', 100, 200)");
+        }
+
+        MysqlBackendConfig cfg = new MysqlBackendConfig(
+                "127.0.0.1", flavor.port, "grim", "root", flavor.rootPassword,
+                "", 256, TableNames.DEFAULTS);
+        MysqlBackend b = new MysqlBackend(cfg);
+        b.init(ctx(tempDir));
+
+        try {
+            // Inspect the post-migration shape directly.
+            try (Connection c = DriverManager.getConnection(flavor.adminUrl() + "&database=grim", "root", flavor.rootPassword);
+                 Statement s = c.createStatement()) {
+                try (ResultSet rs = s.executeQuery("SELECT schema_version FROM grim.grim_meta WHERE id = 0")) {
+                    org.junit.jupiter.api.Assertions.assertTrue(rs.next());
+                    assertEquals(8, rs.getInt(1), "schema_version bumped to 8");
+                }
+                try (ResultSet rs = s.executeQuery(
+                        "SELECT current_name_lower FROM grim.grim_players WHERE uuid = UNHEX('0000000000000000000000000000007F')")) {
+                    org.junit.jupiter.api.Assertions.assertTrue(rs.next());
+                    assertEquals("camelcasename", rs.getString(1),
+                            "STORED gen col backfilled the existing seed row");
+                }
+                // The post-migration index must be on current_name_lower (a real
+                // column), not on the functional expression LOWER(current_name).
+                int columnIndexEntries = 0;
+                try (ResultSet rs = s.executeQuery(
+                        "SHOW INDEX FROM grim.grim_players WHERE Key_name = 'idx_grim_players_name_lower'")) {
+                    while (rs.next()) {
+                        if ("current_name_lower".equals(rs.getString("Column_name"))) {
+                            columnIndexEntries++;
+                        }
+                    }
+                }
+                assertEquals(1, columnIndexEntries,
+                        "idx_grim_players_name_lower now indexes the column, not the LOWER() expression");
+            }
+
+            // End-to-end read after migration: existing seed row should be
+            // findable via the case-insensitive name lookup.
+            Page<PlayerIdentity> byName = b.read(Categories.PLAYER_IDENTITY,
+                    new Queries.GetPlayerIdentityByName("camelcasename"));
+            assertEquals(1, byName.items().size(), "post-migration name lookup finds seed row");
+            assertEquals("CamelCaseName", byName.items().get(0).currentName());
+
+            Page<PlayerIdentity> prefix = b.read(Categories.PLAYER_IDENTITY,
+                    Queries.listPlayersByNamePrefix("camel", 25));
+            assertEquals(1, prefix.items().size(), "post-migration prefix lookup hits the new index");
         } finally {
             try { b.close(); } catch (BackendException ignore) {}
         }

--- a/grim-internal/src/test/java/ac/grim/grimac/internal/storage/backend/mysql/MysqlBackendDialectTest.java
+++ b/grim-internal/src/test/java/ac/grim/grimac/internal/storage/backend/mysql/MysqlBackendDialectTest.java
@@ -1,0 +1,223 @@
+package ac.grim.grimac.internal.storage.backend.mysql;
+
+import ac.grim.grimac.api.storage.backend.BackendConfig;
+import ac.grim.grimac.api.storage.backend.BackendContext;
+import ac.grim.grimac.api.storage.backend.BackendException;
+import ac.grim.grimac.api.storage.backend.StorageEventHandler;
+import ac.grim.grimac.api.storage.category.Categories;
+import ac.grim.grimac.api.storage.config.TableNames;
+import ac.grim.grimac.api.storage.event.PlayerIdentityEvent;
+import ac.grim.grimac.api.storage.event.SessionEvent;
+import ac.grim.grimac.api.storage.event.SettingEvent;
+import ac.grim.grimac.api.storage.event.ViolationEvent;
+import ac.grim.grimac.api.storage.model.PlayerIdentity;
+import ac.grim.grimac.api.storage.model.SessionRecord;
+import ac.grim.grimac.api.storage.model.SettingRecord;
+import ac.grim.grimac.api.storage.model.SettingScope;
+import ac.grim.grimac.api.storage.model.VerboseFormat;
+import ac.grim.grimac.api.storage.model.ViolationRecord;
+import ac.grim.grimac.api.storage.query.Page;
+import ac.grim.grimac.api.storage.query.Queries;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.io.TempDir;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+
+import java.nio.file.Path;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.Locale;
+import java.util.UUID;
+import java.util.logging.Logger;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
+/**
+ * End-to-end round-trip for {@link MysqlBackend} against both server flavors,
+ * driving real {@link MysqlEightDialect} (port 3306, mysql:8.4 fixture) and
+ * {@link MariaDbDialect} (port 3307, mariadb:10.11 fixture) paths.
+ * <p>
+ * Skips per flavor if the fixture isn't reachable, so the test is a no-op on
+ * machines without the per-zone test-data containers (CI runners, contributor
+ * laptops). The fixture creds are the static values committed to
+ * {@code /opt/grim-setup/test-data.conf} — they aren't secrets, the daemons
+ * are reachable only inside the gluetun netns.
+ * <p>
+ * Both dialects MUST observe identical read-back semantics: same identity
+ * upsert merging, case-insensitive name lookup, prefix search, session
+ * latest-wins, settings UPSERT on composite PK, paged violation reads.
+ */
+class MysqlBackendDialectTest {
+
+    private enum Flavor {
+        MYSQL("mysql", 3306, "grim-test-mysql-root", MysqlEightDialect.class),
+        MARIADB("mariadb", 3307, "grim-test-mariadb-root", MariaDbDialect.class);
+
+        final String label;
+        final int port;
+        final String rootPassword;
+        final Class<? extends MysqlDialect> expectedDialect;
+
+        Flavor(String label, int port, String rootPassword, Class<? extends MysqlDialect> expectedDialect) {
+            this.label = label;
+            this.port = port;
+            this.rootPassword = rootPassword;
+            this.expectedDialect = expectedDialect;
+        }
+
+        String adminUrl() {
+            return "jdbc:mysql://127.0.0.1:" + port + "/?useSSL=false&allowPublicKeyRetrieval=true&connectTimeout=2000";
+        }
+    }
+
+    @ParameterizedTest(name = "{0}")
+    @EnumSource(Flavor.class)
+    @DisplayName("MySQL/MariaDB dialect — fresh schema + write/read/upsert-merge round-trip")
+    void roundTrip(Flavor flavor, @TempDir Path tempDir) throws Exception {
+        assumeTrue(reachable(flavor), () ->
+                "Skipping; " + flavor.label + " fixture not reachable on 127.0.0.1:" + flavor.port);
+
+        // Fresh DB so applyBaseline runs (the migrations path is exercised by a
+        // separate test that pre-seeds an old version row — out of scope here).
+        try (Connection admin = DriverManager.getConnection(flavor.adminUrl(), "root", flavor.rootPassword);
+             Statement s = admin.createStatement()) {
+            s.executeUpdate("DROP DATABASE IF EXISTS grim");
+            s.executeUpdate("CREATE DATABASE grim CHARACTER SET utf8mb4");
+        }
+
+        MysqlBackendConfig cfg = new MysqlBackendConfig(
+                "127.0.0.1", flavor.port, "grim", "root", flavor.rootPassword,
+                "", 256, TableNames.DEFAULTS);
+        MysqlBackend b = new MysqlBackend(cfg);
+        b.init(ctx(tempDir));
+
+        try {
+            assertSame(flavor.expectedDialect, b.dialectForTest().getClass(),
+                    "Wrong dialect picked for " + flavor.label);
+
+            UUID player = UUID.randomUUID();
+            UUID session = UUID.randomUUID();
+            long t0 = 1_700_000_000_000L;
+
+            // identity: two writes with bracketing timestamps; expect first_seen=min,
+            // last_seen=max, current_name=second-write.
+            StorageEventHandler<PlayerIdentityEvent> ih = b.eventHandlerFor(Categories.PLAYER_IDENTITY);
+            ih.onEvent(newIdentity(player, "AlphaBravo", t0 + 100, t0 + 100), 0, false);
+            ih.onEvent(newIdentity(player, "charlieDelta", t0, t0 + 500), 1, true);
+
+            StorageEventHandler<SessionEvent> sh = b.eventHandlerFor(Categories.SESSION);
+            sh.onEvent(newSession(session, player, "srv-1", t0, t0), 0, false);
+            sh.onEvent(newSession(session, player, "srv-2", t0, t0 + 1000), 1, true);
+
+            StorageEventHandler<ViolationEvent> vh = b.eventHandlerFor(Categories.VIOLATION);
+            for (int i = 0; i < 5; i++) {
+                ViolationEvent v = new ViolationEvent();
+                v.sessionId(session).playerUuid(player).checkId(42 + i).vl(1.0 + i)
+                        .occurredEpochMs(t0 + i).verbose("v" + i).verboseFormat(VerboseFormat.TEXT);
+                vh.onEvent(v, i, i == 4);
+            }
+
+            StorageEventHandler<SettingEvent> seth = b.eventHandlerFor(Categories.SETTING);
+            seth.onEvent(newSetting("hello", "world-1".getBytes(), t0), 0, false);
+            seth.onEvent(newSetting("hello", "world-2".getBytes(), t0 + 1), 1, true);
+
+            // --- reads ---
+            Page<PlayerIdentity> idPage = b.read(Categories.PLAYER_IDENTITY, new Queries.GetPlayerIdentity(player));
+            assertEquals(1, idPage.items().size(), "identity row count");
+            PlayerIdentity id = idPage.items().get(0);
+            assertEquals("charlieDelta", id.currentName(), "current_name = latest write");
+            assertEquals(t0, id.firstSeenEpochMs(), "first_seen = min of writes");
+            assertEquals(t0 + 500, id.lastSeenEpochMs(), "last_seen = max of writes");
+
+            // The case-insensitive name path is the load-bearing one for the
+            // MariaDB schema: it must hit the STORED generated column index,
+            // not fall back to a full-table scan.
+            Page<PlayerIdentity> byName = b.read(Categories.PLAYER_IDENTITY,
+                    new Queries.GetPlayerIdentityByName("charliedelta"));
+            assertEquals(1, byName.items().size(), "case-insensitive name lookup");
+
+            Page<PlayerIdentity> byNameMixedCase = b.read(Categories.PLAYER_IDENTITY,
+                    new Queries.GetPlayerIdentityByName("CHARLIEDELTA"));
+            assertEquals(1, byNameMixedCase.items().size(), "case-insensitive name lookup (uppercase input)");
+
+            Page<PlayerIdentity> prefix = b.read(Categories.PLAYER_IDENTITY,
+                    Queries.listPlayersByNamePrefix("char", 25));
+            assertEquals(1, prefix.items().size(), "prefix search finds the identity");
+
+            Page<PlayerIdentity> prefixEmpty = b.read(Categories.PLAYER_IDENTITY,
+                    Queries.listPlayersByNamePrefix("", 25));
+            assertEquals(0, prefixEmpty.items().size(), "empty prefix returns empty page");
+
+            Page<SessionRecord> sbi = b.read(Categories.SESSION, new Queries.GetSessionById(session));
+            assertEquals(1, sbi.items().size(), "session row count");
+            SessionRecord s = sbi.items().get(0);
+            assertEquals("srv-2", s.serverName(), "session server_name = latest write");
+            assertEquals(t0 + 1000, s.lastActivityEpochMs(), "session last_activity = latest write");
+
+            Page<ViolationRecord> vs = b.read(Categories.VIOLATION,
+                    new Queries.ListViolationsInSession(session, 10, null));
+            assertEquals(5, vs.items().size(), "violation row count");
+
+            Page<SettingRecord> sr = b.read(Categories.SETTING,
+                    new Queries.GetSetting(SettingScope.SERVER, "grim-core", "hello"));
+            assertEquals(1, sr.items().size(), "setting row count");
+            assertEquals("world-2", new String(sr.items().get(0).value()), "setting value = latest write");
+            assertEquals(t0 + 1, sr.items().get(0).updatedEpochMs(), "setting updated_at = latest write");
+
+            assertEquals(5L, b.countViolationsInSession(session), "countViolationsInSession");
+            assertEquals(1L, b.countSessionsByPlayer(player), "countSessionsByPlayer");
+
+            Page<ViolationRecord> first = b.read(Categories.VIOLATION,
+                    new Queries.ListViolationsInSession(session, 2, null));
+            assertEquals(2, first.items().size(), "page 1 size");
+            assertNotNull(first.nextCursor(), "page 1 has cursor");
+        } finally {
+            try { b.close(); } catch (BackendException ignore) {}
+        }
+    }
+
+    private static boolean reachable(Flavor f) {
+        try (Connection c = DriverManager.getConnection(f.adminUrl(), "root", f.rootPassword)) {
+            return c.isValid(2);
+        } catch (SQLException e) {
+            return false;
+        }
+    }
+
+    private static PlayerIdentityEvent newIdentity(UUID uuid, String name, long firstSeen, long lastSeen) {
+        PlayerIdentityEvent e = new PlayerIdentityEvent();
+        e.uuid(uuid).currentName(name).firstSeenEpochMs(firstSeen).lastSeenEpochMs(lastSeen);
+        return e;
+    }
+
+    private static SessionEvent newSession(UUID sessionId, UUID playerUuid, String serverName,
+                                           long startedAt, long lastActivity) {
+        SessionEvent s = new SessionEvent();
+        s.sessionId(sessionId).playerUuid(playerUuid).serverName(serverName)
+                .startedEpochMs(startedAt).lastActivityEpochMs(lastActivity)
+                .grimVersion("test").clientBrand("vanilla")
+                .clientVersion(772).serverVersionString("1.21.11");
+        return s;
+    }
+
+    private static SettingEvent newSetting(String key, byte[] value, long updatedAt) {
+        SettingEvent e = new SettingEvent();
+        e.scope(SettingScope.SERVER).scopeKey("grim-core").key(key)
+                .value(value).updatedEpochMs(updatedAt);
+        return e;
+    }
+
+    private static BackendContext ctx(Path dataDir) {
+        Logger log = Logger.getLogger("mysql-dialect-test");
+        return new BackendContext() {
+            @Override public BackendConfig config() { return null; }
+            @Override public Logger logger() { return log; }
+            @Override public Path dataDirectory() { return dataDir; }
+        };
+    }
+}


### PR DESCRIPTION
## Summary

Adds MariaDB 10.6+ support to the MySQL backend AND fixes a pre-existing perf bug on the MySQL side, in one go. Both flavors now share the same baseline DDL (a STORED `current_name_lower` generated column with a plain B-tree index) and the same read SQL — only upsert syntax differs (`AS new …` on MySQL 8, `… VALUES(col)` on MariaDB).

## Four commits, one concept each

1. **`mysql: introduce MysqlDialect + MysqlEightDialect (no behavior change)`** — pure refactor; current MySQL-8 SQL extracted into a `MysqlDialect` interface byte-for-byte.
2. **`mysql: add MariaDbDialect + version-probed dialect selection (10.6+ floor)`** — STORED gen col + plain index, legacy `VALUES()` upsert, version probe via `SELECT VERSION()` (handles MariaDB's `5.5.5-` legacy compat prefix), 10.6 LTS floor enforced with a clean `BackendException` if older.
3. **`mysql: dialect round-trip test against live mysql/mariadb fixtures`** — parameterised JUnit, skip-if-fixture-absent.
4. **`mysql: unify dialects on STORED gen col + v7→v8 migration`** — drops the MySQL functional-index path; both dialects converge on the gen col shape. Auto-migration on startup for existing v7 MySQL DBs (additive ALTER, MySQL 8 falls back to `ALGORITHM=COPY` for STORED columns; fine on alpha tables). MariaDB v7 deployments are already at the v8 shape so the migration is a no-op for them.

## Why commit 4 also exists

While verifying MariaDB I measured the MySQL functional-index path and found it doesn't actually use the index for prefix LIKE — only equality. EXPLAIN at 1M rows showed `type: ALL` for `WHERE LOWER(current_name) LIKE 'prefix%'` even with `FORCE INDEX`; `listPlayersByNamePrefix` was an O(table-size) full scan regardless of selectivity. The gen col shape gets `type: range` and scales with prefix selectivity instead of table size.

Measured speedup at 1M rows on MySQL 8.4 (live `test-mysql-zone-a` fixture):

| Prefix | Matches | v7 (functional idx) | v8 (gen col) | Speedup |
|---|---|---|---|---|
| selective 5+ char (typical autocomplete) | 0–100 | ~1100 ms | ~1 ms | **~1000×** |
| 4-char `play` (~2.6% selective) | 26,315 | ~1095 ms | ~1270 ms | ~0.85× (random-IO penalty for 26k row fetches outweighs the index range scan benefit on this selectivity) |
| equality `getPlayerIdentityByName` | 1 | already fast | already fast | unchanged |

The dominant case in Grim's actual usage (admins typing partial player names in slash commands — typically 4+ chars, often near-full) is selective, so the practical impact is "autocomplete that was unusable on 1M-row tables becomes instant."

## Auto-migration cost (alpha context)

`ALTER TABLE players ADD COLUMN ... STORED` requires `ALGORITHM=COPY` on MySQL 8 — `INSTANT` and `INPLACE` both error out for STORED gen cols. That means a full table rewrite, blocking writes for the duration. From the populate timings during benchmarking: **~1 minute per 1M rows** on this hardware. Acceptable here because v7 is alpha-only and large prod DBs don't exist yet (per the human's call); for any future post-GA migration the move would be an external online-schema-change tool (gh-ost / pt-online-schema-change).

## Tests

- `MysqlBackendDialectTest` (parameterised on flavor) — fresh-DB v8 baseline round-trip on both MySQL 8.4 and MariaDB 10.11. Identity upsert merging, case-insensitive name lookup, prefix search, session UPSERT, settings UPSERT on composite PK, paged violation reads. Both flavors green.
- `v7ToV8Migration` (MySQL only) — pre-seeds a v7-shape DB with a `CamelCaseName` identity row, boots the backend, verifies `schema_version` is bumped to 8, the STORED column was backfilled to `camelcasename`, the index now references the column not the `LOWER()` expression, and post-migration reads via the case-insensitive name + prefix queries find the row.
- EXPLAIN on MariaDB 10.11 confirms both queries hit `idx_grim_players_name_lower` (range scan for prefix, ref lookup for exact).

## Test plan checklist

- [x] `./gradlew :grim-internal:test --tests MysqlBackendDialectTest` green against live test-mysql + test-mariadb fixtures (3 tests).
- [x] EXPLAIN confirms index usage on both shapes / both flavors where applicable.
- [x] `./gradlew :grim-internal:compileJava` clean.
- [x] No internal `storage.backend.mysql` import leakage to Grim-public / Grim3.0 — only `MysqlBackendProvider` (stable public entry point) is referenced from Grim-public, unchanged in this PR. Grim3.0 has zero references.
- [ ] Verify against MariaDB 11.x and 12.x — additive DDL across MariaDB minor versions, so no further dialect splits expected. Bump `containers/test-mariadb-zone-a.conf` `MARIADB_IMAGE=` to test.

## Infra prerequisite

The test fixture (`test-mariadb-zone-a` quadlet) lives in a separate grim-setup branch (`test-mariadb-fixture` in my container's rw clone). Already deployed locally.

## Consumer impact

Grim-public and Grim3.0 need only a dep bump to pick this up — no source changes. The public surface (`MysqlBackendProvider`, `MysqlBackend.ID`, capabilities/categories) is unchanged.