### PR TITLE
storage: violation id long → UUIDv7

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,1 @@
-version = 1.4.0.0
+version = 1.5.0.0

--- a/grim-internal/src/main/java/ac/grim/grimac/internal/storage/backend/memory/InMemoryBackend.java
+++ b/grim-internal/src/main/java/ac/grim/grimac/internal/storage/backend/memory/InMemoryBackend.java
@@ -23,6 +23,7 @@ import ac.grim.grimac.api.storage.query.Deletes;
 import ac.grim.grimac.api.storage.query.Page;
 import ac.grim.grimac.api.storage.query.Queries;
 import ac.grim.grimac.api.storage.query.Query;
+import ac.grim.grimac.internal.storage.util.UuidV7;
 import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
 
@@ -33,7 +34,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
-import java.util.concurrent.atomic.AtomicLong;
 
 /**
  * In-memory reference backend. Used by tests and as a sanity-bar for other
@@ -53,7 +53,6 @@ public final class InMemoryBackend implements Backend {
 
     public record Config() implements BackendConfig {}
 
-    private final AtomicLong violationIdSeq = new AtomicLong(1);
     private final Object writeMutex = new Object();
     private final HashMap<UUID, List<ViolationRecord>> violationsBySession = new HashMap<>();
     private final HashMap<UUID, List<ViolationRecord>> violationsByPlayer = new HashMap<>();
@@ -140,7 +139,7 @@ public final class InMemoryBackend implements Backend {
     }
 
     private void applyViolation(ViolationEvent v) {
-        long id = violationIdSeq.getAndIncrement();
+        UUID id = v.id() != null ? v.id() : UuidV7.next();
         ViolationRecord stored = new ViolationRecord(
                 id, v.sessionId(), v.playerUuid(), v.checkId(), v.vl(),
                 v.occurredEpochMs(), v.verbose(), v.verboseFormat());
@@ -214,12 +213,10 @@ public final class InMemoryBackend implements Backend {
     }
 
     private void applyViolationRecord(ViolationRecord v) {
-        long id = v.id() == 0 ? violationIdSeq.getAndIncrement() : v.id();
-        ViolationRecord stored = new ViolationRecord(
-                id, v.sessionId(), v.playerUuid(), v.checkId(), v.vl(),
-                v.occurredEpochMs(), v.verbose(), v.verboseFormat());
-        violationsBySession.computeIfAbsent(stored.sessionId(), k -> new ArrayList<>()).add(stored);
-        violationsByPlayer.computeIfAbsent(stored.playerUuid(), k -> new ArrayList<>()).add(stored);
+        // ViolationRecord.id is non-null by record contract — cross-backend
+        // bulkImport / migrate paths always carry an id through.
+        violationsBySession.computeIfAbsent(v.sessionId(), k -> new ArrayList<>()).add(v);
+        violationsByPlayer.computeIfAbsent(v.playerUuid(), k -> new ArrayList<>()).add(v);
     }
 
     private void applySessionRecord(SessionRecord s) {
@@ -268,7 +265,10 @@ public final class InMemoryBackend implements Backend {
             }
             if (query instanceof Queries.ListViolationsInSession q) {
                 List<ViolationRecord> all = new ArrayList<>(violationsBySession.getOrDefault(q.sessionId(), List.of()));
-                all.sort(Comparator.comparingLong(ViolationRecord::occurredEpochMs));
+                // (occurred_at, id) ordering matches the SQL/Mongo backends —
+                // id is the tiebreaker for same-ms bursts.
+                all.sort(Comparator.comparingLong(ViolationRecord::occurredEpochMs)
+                        .thenComparing(ViolationRecord::id));
                 int skip = decodeSkipCursor(q.cursor());
                 int end = Math.min(skip + q.pageSize(), all.size());
                 List<ViolationRecord> slice = all.subList(skip, end);
@@ -327,7 +327,7 @@ public final class InMemoryBackend implements Backend {
                     if (v != null) {
                         for (ViolationRecord r : v) {
                             List<ViolationRecord> perSession = violationsBySession.get(r.sessionId());
-                            if (perSession != null) perSession.removeIf(x -> x.id() == r.id());
+                            if (perSession != null) perSession.removeIf(x -> x.id().equals(r.id()));
                         }
                     }
                 } else if (cat == Categories.SESSION) {

--- a/grim-internal/src/main/java/ac/grim/grimac/internal/storage/backend/memory/InMemoryBackend.java
+++ b/grim-internal/src/main/java/ac/grim/grimac/internal/storage/backend/memory/InMemoryBackend.java
@@ -23,7 +23,6 @@ import ac.grim.grimac.api.storage.query.Deletes;
 import ac.grim.grimac.api.storage.query.Page;
 import ac.grim.grimac.api.storage.query.Queries;
 import ac.grim.grimac.api.storage.query.Query;
-import ac.grim.grimac.internal.storage.util.UuidV7;
 import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
 
@@ -139,7 +138,7 @@ public final class InMemoryBackend implements Backend {
     }
 
     private void applyViolation(ViolationEvent v) {
-        UUID id = v.id() != null ? v.id() : UuidV7.next();
+        UUID id = v.id();
         ViolationRecord stored = new ViolationRecord(
                 id, v.sessionId(), v.playerUuid(), v.checkId(), v.vl(),
                 v.occurredEpochMs(), v.verbose(), v.verboseFormat());

--- a/grim-internal/src/main/java/ac/grim/grimac/internal/storage/backend/mongo/MongoBackend.java
+++ b/grim-internal/src/main/java/ac/grim/grimac/internal/storage/backend/mongo/MongoBackend.java
@@ -70,8 +70,9 @@ import java.util.logging.Logger;
  * subtype 0 (generic) for opaque byte-arrays. Violations key off a UUIDv7
  * {@code id} (also UUID-binary) minted producer-side so multiple JVMs can
  * share one MongoDB cluster without coordinating an allocator. The
- * timestamp prefix on UUIDv7 keeps the unique-index B-tree append-friendly
- * and gives the cursor a single-column ordering ({@code WHERE id > ? ORDER BY id}).
+ * timestamp prefix on UUIDv7 keeps the unique-index B-tree append-friendly;
+ * violation paging orders by {@code (occurred_at, id)} so event time remains
+ * authoritative and the UUID is a stable tie-breaker.
  */
 @ApiStatus.Internal
 public final class MongoBackend implements Backend {
@@ -155,7 +156,8 @@ public final class MongoBackend implements Backend {
         players.createIndex(Indexes.ascending("current_name_lower"));
         sessions.createIndex(Indexes.descending("started_at"));
         sessions.createIndex(Indexes.compoundIndex(Indexes.ascending("player_uuid"), Indexes.descending("started_at")));
-        violations.createIndex(Indexes.compoundIndex(Indexes.ascending("session_id"), Indexes.ascending("occurred_at")));
+        violations.createIndex(Indexes.compoundIndex(
+                Indexes.ascending("session_id"), Indexes.ascending("occurred_at"), Indexes.ascending("id")));
         violations.createIndex(Indexes.ascending("player_uuid"));
         violations.createIndex(Indexes.ascending("id"), new IndexOptions().unique(true));
         settings.createIndex(Indexes.compoundIndex(
@@ -191,9 +193,10 @@ public final class MongoBackend implements Backend {
     /**
      * v5 → v6: violation {@code id} type changes from {@code long} to UUID
      * (UUIDv7, stored as {@link BsonBinary} subtype 4). Each legacy row's
-     * replacement id is synthesised from {@code occurred_at} so chronological
-     * ordering is preserved. The unique index on {@code id} is rebuilt
-     * afterwards because index entries reference the now-replaced byte values.
+     * replacement id is synthesised from {@code occurred_at} and the old
+     * numeric id so same-millisecond ordering is preserved. The unique index
+     * on {@code id} is rebuilt afterwards because index entries reference the
+     * now-replaced byte values.
      */
     private void migrateV5ToV6() {
         logger.info("[grim-datastore] migrating Mongo violations id long→UUIDv7 …");
@@ -209,7 +212,8 @@ public final class MongoBackend implements Backend {
             // Already migrated rows have BsonBinary / Binary ids — skip.
             if (idObj instanceof org.bson.types.Binary || idObj instanceof BsonBinary) continue;
             long occurred = d.getLong("occurred_at") == null ? 0L : d.getLong("occurred_at");
-            UUID newId = UuidV7.fromTimestampMs(occurred);
+            long legacyId = idObj instanceof Number n ? n.longValue() : 0L;
+            UUID newId = UuidV7.fromTimestampMs(occurred, legacyId);
             ops.add(new UpdateOneModel<>(Filters.eq("_id", d.get("_id")),
                     Updates.set("id", binUuid(newId))));
             if (ops.size() >= 1024) {

--- a/grim-internal/src/main/java/ac/grim/grimac/internal/storage/backend/mongo/MongoBackend.java
+++ b/grim-internal/src/main/java/ac/grim/grimac/internal/storage/backend/mongo/MongoBackend.java
@@ -26,6 +26,7 @@ import ac.grim.grimac.api.storage.query.Page;
 import ac.grim.grimac.api.storage.query.Queries;
 import ac.grim.grimac.api.storage.query.Query;
 import ac.grim.grimac.internal.storage.util.UuidCodec;
+import ac.grim.grimac.internal.storage.util.UuidV7;
 import com.mongodb.MongoWriteException;
 import com.mongodb.client.MongoClient;
 import com.mongodb.client.MongoClients;
@@ -56,7 +57,6 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Set;
 import java.util.UUID;
-import java.util.concurrent.atomic.AtomicLong;
 import java.util.logging.Logger;
 
 /**
@@ -67,14 +67,22 @@ import java.util.logging.Logger;
  * <p>
  * Binary fields (UUIDs, setting values) are stored as
  * {@link org.bson.BsonBinary} with subtype 4 (UUID) for id-like fields and
- * subtype 0 (generic) for opaque byte-arrays. Violations use a monotonic
- * {@code id} long (auto-incremented via a counter doc in {@code meta}) instead
- * of ObjectId — keeps the cursor scheme identical to the SQL backends.
+ * subtype 0 (generic) for opaque byte-arrays. Violations key off a UUIDv7
+ * {@code id} (also UUID-binary) minted producer-side so multiple JVMs can
+ * share one MongoDB cluster without coordinating an allocator. The
+ * timestamp prefix on UUIDv7 keeps the unique-index B-tree append-friendly
+ * and gives the cursor a single-column ordering ({@code WHERE id > ? ORDER BY id}).
  */
 @ApiStatus.Internal
 public final class MongoBackend implements Backend {
 
     public static final String ID = "mongo";
+
+    /**
+     * Bumped on every breaking shape change; {@link #migrateSchema(int)}
+     * runs forward migrations for any older value found in the meta doc.
+     */
+    static final int CURRENT_SCHEMA_VERSION = 6;
 
     private final MongoBackendConfig config;
     private final List<BatchingHandler<?>> handlers = new ArrayList<>();
@@ -82,8 +90,6 @@ public final class MongoBackend implements Backend {
     private MongoDatabase db;
     private MongoCollection<Document> meta, players, sessions, violations, settings;
     private Logger logger;
-    /** Monotonic violation id; seeded from the current max at init(). */
-    private final AtomicLong violationIdSeq = new AtomicLong();
 
     public MongoBackend(MongoBackendConfig config) {
         this.config = config;
@@ -128,12 +134,21 @@ public final class MongoBackend implements Backend {
             this.sessions = db.getCollection(t.sessions());
             this.violations = db.getCollection(t.violations());
             this.settings = db.getCollection(t.settings());
-            ensureIndexes();
+            int existingVersion = readSchemaVersion();
             ensureMetaDoc();
-            seedViolationIdSeq();
+            if (existingVersion >= 0 && existingVersion < CURRENT_SCHEMA_VERSION) {
+                migrateSchema(existingVersion);
+            }
+            ensureIndexes();
         } catch (RuntimeException e) {
             throw new BackendException("failed to initialise Mongo backend", e);
         }
+    }
+
+    private int readSchemaVersion() {
+        Document metaDoc = meta.find(Filters.eq("_id", 0)).first();
+        if (metaDoc == null) return -1;
+        return metaDoc.getInteger("schema_version", 0);
     }
 
     private void ensureIndexes() {
@@ -153,26 +168,61 @@ public final class MongoBackend implements Backend {
         if (metaDoc == null) {
             long now = System.currentTimeMillis();
             meta.insertOne(new Document("_id", 0)
-                    .append("schema_version", 5)
+                    .append("schema_version", CURRENT_SCHEMA_VERSION)
                     .append("grim_core_version", "phase1")
                     .append("initialized_at", now)
-                    .append("last_migration_at", now)
-                    .append("violation_id_seq", 0L));
+                    .append("last_migration_at", now));
         }
     }
 
-    private void seedViolationIdSeq() {
-        // Pick up where the last run left off. Prefer the counter on the meta doc
-        // (bumped on every insert); fall back to SELECT max(id) on the violations
-        // collection if the counter is stale because an operator bulk-imported
-        // rows by hand.
-        Document metaDoc = meta.find(Filters.eq("_id", 0)).first();
-        long seq = metaDoc != null && metaDoc.get("violation_id_seq") != null
-                ? metaDoc.getLong("violation_id_seq")
-                : 0L;
-        Document top = violations.find().sort(new Document("id", -1)).limit(1).first();
-        long top_id = top == null ? 0L : top.getLong("id");
-        violationIdSeq.set(Math.max(seq, top_id));
+    /**
+     * Forward-only schema migrations. Each step is idempotent (gated on
+     * {@code existing < N}) and updates {@code schema_version} on success.
+     */
+    private void migrateSchema(int existing) {
+        if (existing < 6) migrateV5ToV6();
+        meta.updateOne(Filters.eq("_id", 0),
+                Updates.combine(
+                        Updates.set("schema_version", CURRENT_SCHEMA_VERSION),
+                        Updates.set("last_migration_at", System.currentTimeMillis()),
+                        Updates.unset("violation_id_seq")));
+    }
+
+    /**
+     * v5 → v6: violation {@code id} type changes from {@code long} to UUID
+     * (UUIDv7, stored as {@link BsonBinary} subtype 4). Each legacy row's
+     * replacement id is synthesised from {@code occurred_at} so chronological
+     * ordering is preserved. The unique index on {@code id} is rebuilt
+     * afterwards because index entries reference the now-replaced byte values.
+     */
+    private void migrateV5ToV6() {
+        logger.info("[grim-datastore] migrating Mongo violations id long→UUIDv7 …");
+        try {
+            violations.dropIndex(Indexes.ascending("id"));
+        } catch (RuntimeException ignore) {
+            // Index may not exist (fresh-ish DB); ensureIndexes() recreates it.
+        }
+        long count = 0;
+        List<WriteModel<Document>> ops = new ArrayList<>();
+        for (Document d : violations.find().projection(new Document("_id", 1).append("id", 1).append("occurred_at", 1))) {
+            Object idObj = d.get("id");
+            // Already migrated rows have BsonBinary / Binary ids — skip.
+            if (idObj instanceof org.bson.types.Binary || idObj instanceof BsonBinary) continue;
+            long occurred = d.getLong("occurred_at") == null ? 0L : d.getLong("occurred_at");
+            UUID newId = UuidV7.fromTimestampMs(occurred);
+            ops.add(new UpdateOneModel<>(Filters.eq("_id", d.get("_id")),
+                    Updates.set("id", binUuid(newId))));
+            if (ops.size() >= 1024) {
+                violations.bulkWrite(ops);
+                count += ops.size();
+                ops.clear();
+            }
+        }
+        if (!ops.isEmpty()) {
+            violations.bulkWrite(ops);
+            count += ops.size();
+        }
+        logger.info("[grim-datastore] migrated " + count + " violation rows to UUIDv7 id");
     }
 
     @Override public void flush() {}
@@ -241,12 +291,11 @@ public final class MongoBackend implements Backend {
         @Override protected String categoryId() { return "violation"; }
         @Override
         protected void append(ViolationEvent v) {
-            long id = violationIdSeq.incrementAndGet();
+            // Sink populates event.id() with a UUIDv7 in the normal path; the
+            // null branch is a backstop for fixtures that bypass the sink.
+            UUID id = v.id() != null ? v.id() : UuidV7.next();
             pending.add(new InsertOneModel<>(violationDoc(id, v.sessionId(), v.playerUuid(),
                     v.checkId(), v.vl(), v.occurredEpochMs(), v.verbose(), v.verboseFormat())));
-            // Bump the counter on meta so seedViolationIdSeq picks up on restart.
-            // Single-writer per handler → safe without $inc atomicity concerns.
-            meta.updateOne(Filters.eq("_id", 0), Updates.set("violation_id_seq", id));
         }
     }
 
@@ -330,11 +379,11 @@ public final class MongoBackend implements Backend {
         return new BsonBinary(UuidCodec.toBytes(u));
     }
 
-    private static Document violationDoc(long id, UUID session, UUID player, int checkId,
+    private static Document violationDoc(UUID id, UUID session, UUID player, int checkId,
                                          double vl, long occurred, String verbose,
                                          VerboseFormat fmt) {
         return new Document()
-                .append("id", id)
+                .append("id", binUuid(id))
                 .append("session_id", binUuid(session))
                 .append("player_uuid", binUuid(player))
                 .append("check_id", checkId)
@@ -404,16 +453,15 @@ public final class MongoBackend implements Backend {
     }
 
     private void bulkViolations(List<ViolationRecord> rows) {
+        // ViolationRecord.id is non-null by record contract — bulkImport from
+        // any backend preserves the upstream id verbatim, no mint needed.
         List<Document> docs = new ArrayList<>(rows.size());
         for (ViolationRecord v : rows) {
-            long id = v.id() > 0 ? v.id() : violationIdSeq.incrementAndGet();
-            docs.add(violationDoc(id, v.sessionId(), v.playerUuid(), v.checkId(), v.vl(),
+            docs.add(violationDoc(v.id(), v.sessionId(), v.playerUuid(), v.checkId(), v.vl(),
                     v.occurredEpochMs(), v.verbose(), v.verboseFormat()));
         }
         if (!docs.isEmpty()) {
             violations.insertMany(docs, new InsertManyOptions().ordered(false));
-            long maxId = docs.stream().mapToLong(d -> d.getLong("id")).max().orElse(0);
-            meta.updateOne(Filters.eq("_id", 0), Updates.max("violation_id_seq", maxId));
         }
     }
 
@@ -513,18 +561,24 @@ public final class MongoBackend implements Backend {
     }
 
     private Page<ViolationRecord> listViolationsInSession(Queries.ListViolationsInSession q) {
+        // Order by (occurred_at, id) — id is wall-clock at mint time and can
+        // drift from event time when callers pre-set event.id(), when ring
+        // slots sit before the sink runs, or when bulkImport carries through
+        // original ids. Id stays as the tiebreaker for same-ms bursts.
         long lastOccurred = decodeViolationOccurredCursor(q.cursor(), Long.MIN_VALUE);
-        long lastId = decodeViolationIdCursor(q.cursor());
+        UUID lastId = decodeViolationIdCursor(q.cursor());
         Bson sessionEq = Filters.eq("session_id", binUuid(q.sessionId()));
-        Bson pageFilter = Filters.or(
-                Filters.gt("occurred_at", lastOccurred),
-                Filters.and(Filters.eq("occurred_at", lastOccurred),
-                        Filters.gt("id", lastId)));
+        Bson finalFilter = lastId == null
+                ? sessionEq
+                : Filters.and(sessionEq, Filters.or(
+                        Filters.gt("occurred_at", lastOccurred),
+                        Filters.and(Filters.eq("occurred_at", lastOccurred),
+                                Filters.gt("id", binUuid(lastId)))));
         List<ViolationRecord> out = new ArrayList<>();
         boolean hasMore = false;
         List<Document> docs = new ArrayList<>();
         for (Document d : violations
-                .find(Filters.and(sessionEq, pageFilter))
+                .find(finalFilter)
                 .sort(new Document("occurred_at", 1).append("id", 1))
                 .limit(q.pageSize() + 1)) {
             docs.add(d);
@@ -608,7 +662,7 @@ public final class MongoBackend implements Backend {
 
     private static ViolationRecord mapViolation(Document d) {
         return new ViolationRecord(
-                d.getLong("id"),
+                UuidCodec.fromBytes(binBytes(d.get("id"))),
                 UuidCodec.fromBytes(binBytes(d.get("session_id"))),
                 UuidCodec.fromBytes(binBytes(d.get("player_uuid"))),
                 d.getInteger("check_id"),
@@ -749,24 +803,24 @@ public final class MongoBackend implements Backend {
         return out;
     }
 
-    private static Cursor encodeViolationCursor(long occurred, long id) {
-        return new Cursor("v:" + occurred + ":" + id);
+    private static Cursor encodeViolationCursor(long occurredAt, UUID id) {
+        return new Cursor("v:" + occurredAt + ":" + id);
     }
 
     private static long decodeViolationOccurredCursor(Cursor c, long defaultVal) {
         if (c == null) return defaultVal;
-        String[] parts = c.token().split(":");
-        if (parts.length < 3) return defaultVal;
+        String[] parts = c.token().split(":", 3);
+        if (parts.length < 3 || !"v".equals(parts[0])) return defaultVal;
         try { return Long.parseLong(parts[1]); }
         catch (NumberFormatException e) { return defaultVal; }
     }
 
-    private static long decodeViolationIdCursor(Cursor c) {
-        if (c == null) return Long.MIN_VALUE;
-        String[] parts = c.token().split(":");
-        if (parts.length < 3) return Long.MIN_VALUE;
-        try { return Long.parseLong(parts[2]); }
-        catch (NumberFormatException e) { return Long.MIN_VALUE; }
+    private static UUID decodeViolationIdCursor(Cursor c) {
+        if (c == null) return null;
+        String[] parts = c.token().split(":", 3);
+        if (parts.length < 3 || !"v".equals(parts[0])) return null;
+        try { return UUID.fromString(parts[2]); }
+        catch (IllegalArgumentException e) { return null; }
     }
 
     @ApiStatus.Internal

--- a/grim-internal/src/main/java/ac/grim/grimac/internal/storage/backend/mongo/MongoBackend.java
+++ b/grim-internal/src/main/java/ac/grim/grimac/internal/storage/backend/mongo/MongoBackend.java
@@ -291,9 +291,7 @@ public final class MongoBackend implements Backend {
         @Override protected String categoryId() { return "violation"; }
         @Override
         protected void append(ViolationEvent v) {
-            // Sink populates event.id() with a UUIDv7 in the normal path; the
-            // null branch is a backstop for fixtures that bypass the sink.
-            UUID id = v.id() != null ? v.id() : UuidV7.next();
+            UUID id = v.id();
             pending.add(new InsertOneModel<>(violationDoc(id, v.sessionId(), v.playerUuid(),
                     v.checkId(), v.vl(), v.occurredEpochMs(), v.verbose(), v.verboseFormat())));
         }

--- a/grim-internal/src/main/java/ac/grim/grimac/internal/storage/backend/mysql/MysqlBackend.java
+++ b/grim-internal/src/main/java/ac/grim/grimac/internal/storage/backend/mysql/MysqlBackend.java
@@ -25,6 +25,7 @@ import ac.grim.grimac.api.storage.query.Page;
 import ac.grim.grimac.api.storage.query.Queries;
 import ac.grim.grimac.api.storage.query.Query;
 import ac.grim.grimac.internal.storage.util.UuidCodec;
+import ac.grim.grimac.internal.storage.util.UuidV7;
 import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
 
@@ -88,8 +89,8 @@ public final class MysqlBackend implements Backend {
         TableNames t = config.tableNames();
         // Flavor-agnostic — plain INSERT, no ON DUPLICATE KEY clause.
         this.insertViolations =
-                "INSERT INTO " + t.violations() + "(session_id, player_uuid, check_id, vl, occurred_at, verbose, verbose_format) "
-                        + "VALUES (?, ?, ?, ?, ?, ?, ?)";
+                "INSERT INTO " + t.violations() + "(id, session_id, player_uuid, check_id, vl, occurred_at, verbose, verbose_format) "
+                        + "VALUES (?, ?, ?, ?, ?, ?, ?, ?)";
     }
 
     @Override public @NotNull String id() { return ID; }
@@ -343,13 +344,15 @@ public final class MysqlBackend implements Backend {
         @Override protected String categoryId() { return "violation"; }
         @Override
         protected void bind(PreparedStatement ps, ViolationEvent v) throws SQLException {
-            ps.setBytes(1, UuidCodec.toBytes(v.sessionId()));
-            ps.setBytes(2, UuidCodec.toBytes(v.playerUuid()));
-            ps.setInt(3, v.checkId());
-            ps.setDouble(4, v.vl());
-            ps.setLong(5, v.occurredEpochMs());
-            ps.setString(6, v.verbose());
-            ps.setInt(7, v.verboseFormat().code());
+            UUID id = v.id() != null ? v.id() : UuidV7.next();
+            ps.setBytes(1, UuidCodec.toBytes(id));
+            ps.setBytes(2, UuidCodec.toBytes(v.sessionId()));
+            ps.setBytes(3, UuidCodec.toBytes(v.playerUuid()));
+            ps.setInt(4, v.checkId());
+            ps.setDouble(5, v.vl());
+            ps.setLong(6, v.occurredEpochMs());
+            ps.setString(7, v.verbose());
+            ps.setInt(8, v.verboseFormat().code());
         }
     }
 
@@ -431,13 +434,14 @@ public final class MysqlBackend implements Backend {
     private void writeViolationRecords(List<ViolationRecord> rows) throws SQLException {
         try (PreparedStatement ps = writeConn.prepareStatement(insertViolations)) {
             for (ViolationRecord v : rows) {
-                ps.setBytes(1, UuidCodec.toBytes(v.sessionId()));
-                ps.setBytes(2, UuidCodec.toBytes(v.playerUuid()));
-                ps.setInt(3, v.checkId());
-                ps.setDouble(4, v.vl());
-                ps.setLong(5, v.occurredEpochMs());
-                ps.setString(6, v.verbose());
-                ps.setInt(7, v.verboseFormat().code());
+                ps.setBytes(1, UuidCodec.toBytes(v.id()));
+                ps.setBytes(2, UuidCodec.toBytes(v.sessionId()));
+                ps.setBytes(3, UuidCodec.toBytes(v.playerUuid()));
+                ps.setInt(4, v.checkId());
+                ps.setDouble(5, v.vl());
+                ps.setLong(6, v.occurredEpochMs());
+                ps.setString(7, v.verbose());
+                ps.setInt(8, v.verboseFormat().code());
                 ps.addBatch();
             }
             ps.executeBatch();
@@ -557,8 +561,12 @@ public final class MysqlBackend implements Backend {
     }
 
     private Page<ViolationRecord> listViolationsInSession(Connection c, Queries.ListViolationsInSession q) throws SQLException {
+        // Order by (occurred_at, id) — id is wall-clock at mint time and can drift
+        // from event time when callers pre-set event.id(), when ring slots sit
+        // before the sink runs, or when bulkImport carries through original ids.
+        // Id stays as the tiebreaker for same-ms bursts.
         long lastOccurred = decodeViolationOccurredCursor(q.cursor(), Long.MIN_VALUE);
-        long lastId = decodeViolationIdCursor(q.cursor());
+        byte[] lastId = decodeViolationIdCursor(q.cursor());
         try (PreparedStatement ps = c.prepareStatement(
                 "SELECT id, session_id, player_uuid, check_id, vl, occurred_at, verbose, verbose_format "
                         + "FROM " + config.tableNames().violations() + " "
@@ -568,7 +576,7 @@ public final class MysqlBackend implements Backend {
             ps.setBytes(1, UuidCodec.toBytes(q.sessionId()));
             ps.setLong(2, lastOccurred);
             ps.setLong(3, lastOccurred);
-            ps.setLong(4, lastId);
+            ps.setBytes(4, lastId);
             ps.setInt(5, q.pageSize() + 1);
             try (ResultSet rs = ps.executeQuery()) {
                 List<ViolationRecord> out = new ArrayList<>();
@@ -665,7 +673,7 @@ public final class MysqlBackend implements Backend {
 
     private static ViolationRecord mapViolation(ResultSet rs) throws SQLException {
         return new ViolationRecord(
-                rs.getLong("id"),
+                UuidCodec.fromBytes(rs.getBytes("id")),
                 UuidCodec.fromBytes(rs.getBytes("session_id")),
                 UuidCodec.fromBytes(rs.getBytes("player_uuid")),
                 rs.getInt("check_id"),
@@ -829,24 +837,24 @@ public final class MysqlBackend implements Backend {
         return out;
     }
 
-    private static Cursor encodeViolationCursor(long occurred, long id) {
-        return new Cursor("v:" + occurred + ":" + id);
+    private static Cursor encodeViolationCursor(long occurredAt, UUID id) {
+        return new Cursor("v:" + occurredAt + ":" + id);
     }
 
     private static long decodeViolationOccurredCursor(Cursor c, long defaultVal) {
         if (c == null) return defaultVal;
-        String[] parts = c.token().split(":");
-        if (parts.length < 3) return defaultVal;
+        String[] parts = c.token().split(":", 3);
+        if (parts.length < 3 || !"v".equals(parts[0])) return defaultVal;
         try { return Long.parseLong(parts[1]); }
         catch (NumberFormatException e) { return defaultVal; }
     }
 
-    private static long decodeViolationIdCursor(Cursor c) {
-        if (c == null) return Long.MIN_VALUE;
-        String[] parts = c.token().split(":");
-        if (parts.length < 3) return Long.MIN_VALUE;
-        try { return Long.parseLong(parts[2]); }
-        catch (NumberFormatException e) { return Long.MIN_VALUE; }
+    private static byte[] decodeViolationIdCursor(Cursor c) {
+        if (c == null) return new byte[16];
+        String[] parts = c.token().split(":", 3);
+        if (parts.length < 3 || !"v".equals(parts[0])) return new byte[16];
+        try { return UuidCodec.toBytes(UUID.fromString(parts[2])); }
+        catch (IllegalArgumentException e) { return new byte[16]; }
     }
 
     @ApiStatus.Internal

--- a/grim-internal/src/main/java/ac/grim/grimac/internal/storage/backend/mysql/MysqlBackend.java
+++ b/grim-internal/src/main/java/ac/grim/grimac/internal/storage/backend/mysql/MysqlBackend.java
@@ -25,7 +25,6 @@ import ac.grim.grimac.api.storage.query.Page;
 import ac.grim.grimac.api.storage.query.Queries;
 import ac.grim.grimac.api.storage.query.Query;
 import ac.grim.grimac.internal.storage.util.UuidCodec;
-import ac.grim.grimac.internal.storage.util.UuidV7;
 import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
 
@@ -344,7 +343,7 @@ public final class MysqlBackend implements Backend {
         @Override protected String categoryId() { return "violation"; }
         @Override
         protected void bind(PreparedStatement ps, ViolationEvent v) throws SQLException {
-            UUID id = v.id() != null ? v.id() : UuidV7.next();
+            UUID id = v.id();
             ps.setBytes(1, UuidCodec.toBytes(id));
             ps.setBytes(2, UuidCodec.toBytes(v.sessionId()));
             ps.setBytes(3, UuidCodec.toBytes(v.playerUuid()));

--- a/grim-internal/src/main/java/ac/grim/grimac/internal/storage/backend/mysql/MysqlDialect.java
+++ b/grim-internal/src/main/java/ac/grim/grimac/internal/storage/backend/mysql/MysqlDialect.java
@@ -86,8 +86,12 @@ public interface MysqlDialect {
                 + "INDEX idx_" + t.sessions() + "_player_started (player_uuid, started_at DESC)"
                 + ") ENGINE=InnoDB DEFAULT CHARSET=utf8mb4");
 
+        // v9: id is a UUIDv7 stored as BINARY(16). The timestamp prefix keeps
+        // the PK B-tree append-friendly (same locality property AUTO_INCREMENT
+        // gave us) while letting many JVMs sharing one MySQL mint ids without
+        // a coordinator.
         s.executeUpdate("CREATE TABLE " + t.violations() + " ("
-                + "id BIGINT AUTO_INCREMENT PRIMARY KEY, "
+                + "id BINARY(16) PRIMARY KEY, "
                 + "session_id BINARY(16) NOT NULL, "
                 + "player_uuid BINARY(16) NOT NULL, "
                 + "check_id INT NOT NULL, "

--- a/grim-internal/src/main/java/ac/grim/grimac/internal/storage/backend/mysql/MysqlDialect.java
+++ b/grim-internal/src/main/java/ac/grim/grimac/internal/storage/backend/mysql/MysqlDialect.java
@@ -100,7 +100,7 @@ public interface MysqlDialect {
                 + "verbose MEDIUMTEXT, "
                 + "verbose_format INT NOT NULL DEFAULT 0, "
                 + "metadata MEDIUMTEXT, "
-                + "INDEX idx_" + t.violations() + "_session_time (session_id, occurred_at), "
+                + "INDEX idx_" + t.violations() + "_session_time (session_id, occurred_at, id), "
                 + "INDEX idx_" + t.violations() + "_player (player_uuid)"
                 + ") ENGINE=InnoDB DEFAULT CHARSET=utf8mb4");
 

--- a/grim-internal/src/main/java/ac/grim/grimac/internal/storage/backend/mysql/MysqlSchema.java
+++ b/grim-internal/src/main/java/ac/grim/grimac/internal/storage/backend/mysql/MysqlSchema.java
@@ -2,6 +2,8 @@ package ac.grim.grimac.internal.storage.backend.mysql;
 
 import ac.grim.grimac.api.storage.config.TableNames;
 import ac.grim.grimac.internal.storage.checks.LegacyKeyRenames;
+import ac.grim.grimac.internal.storage.util.UuidCodec;
+import ac.grim.grimac.internal.storage.util.UuidV7;
 import org.jetbrains.annotations.ApiStatus;
 
 import java.sql.Connection;
@@ -10,6 +12,7 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
 import java.util.Map;
+import java.util.UUID;
 
 /**
  * MySQL-family schema for the MySQL backend. New backends are born at the
@@ -29,7 +32,7 @@ import java.util.Map;
 @ApiStatus.Internal
 public final class MysqlSchema {
 
-    public static final int CURRENT_VERSION = 8;
+    public static final int CURRENT_VERSION = 9;
 
     private MysqlSchema() {}
 
@@ -75,6 +78,7 @@ public final class MysqlSchema {
         if (existing < 6) migrateV5ToV6(c, t);
         if (existing < 7) migrateV6ToV7(c, t);
         if (existing < 8) migrateV7ToV8(c, t, dialect);
+        if (existing < 9) migrateV8ToV9(c, t);
 
         if (existing < CURRENT_VERSION) {
             try (PreparedStatement ps = c.prepareStatement(
@@ -138,6 +142,103 @@ public final class MysqlSchema {
     private static void applyBaseline(Connection c, TableNames t, MysqlDialect dialect) throws SQLException {
         try (Statement s = c.createStatement()) {
             dialect.applyBaseline(s, t);
+        }
+    }
+
+    /**
+     * v8 → v9: violation {@code id} type changes from
+     * {@code BIGINT AUTO_INCREMENT PRIMARY KEY} to {@code BINARY(16) PRIMARY
+     * KEY} carrying a UUIDv7. MySQL/MariaDB can't compute UUIDv7 in pure SQL
+     * (the function is Postgres 18+ only and not portable here), so this
+     * does the same rebuild dance as the SQLite migration: create the new
+     * table, stream rows out, mint UUIDv7s in Java from each row's
+     * {@code occurred_at}, bulk-insert into the new table, swap names.
+     */
+    private static void migrateV8ToV9(Connection c, TableNames t) throws SQLException {
+        String oldTable = t.violations();
+        String newTable = t.violations() + "_uuid_v7_tmp";
+        String backupTable = t.violations() + "_pre_v9_backup";
+
+        // Crash-recovery: if the previous run crashed after the atomic swap
+        // but before the schema_version commit, oldTable already has BINARY(16)
+        // ids and the backup is still hanging around. Skip the rewrite and
+        // drop the leftover backup — meta bump in ensureInitialized finishes.
+        if (violationsIdIsBinary16(c, oldTable)) {
+            try (Statement s = c.createStatement()) {
+                s.executeUpdate("DROP TABLE IF EXISTS " + backupTable);
+            }
+            return;
+        }
+
+        // Stale tmp from an interrupted earlier attempt (crash during copy):
+        // safe to drop because oldTable still has BIGINT ids — i.e. the only
+        // canonical copy lives in oldTable.
+        try (Statement s = c.createStatement()) {
+            s.executeUpdate("DROP TABLE IF EXISTS " + newTable);
+            s.executeUpdate("DROP TABLE IF EXISTS " + backupTable);
+            s.executeUpdate("CREATE TABLE " + newTable + " ("
+                    + "id BINARY(16) PRIMARY KEY, "
+                    + "session_id BINARY(16) NOT NULL, "
+                    + "player_uuid BINARY(16) NOT NULL, "
+                    + "check_id INT NOT NULL, "
+                    + "vl DOUBLE NOT NULL, "
+                    + "occurred_at BIGINT NOT NULL, "
+                    + "verbose MEDIUMTEXT, "
+                    + "verbose_format INT NOT NULL DEFAULT 0, "
+                    + "metadata MEDIUMTEXT, "
+                    + "INDEX idx_" + oldTable + "_session_time (session_id, occurred_at), "
+                    + "INDEX idx_" + oldTable + "_player (player_uuid)"
+                    + ") ENGINE=InnoDB DEFAULT CHARSET=utf8mb4");
+        }
+
+        try (PreparedStatement sel = c.prepareStatement(
+                "SELECT session_id, player_uuid, check_id, vl, occurred_at, verbose, verbose_format, metadata "
+                        + "FROM " + oldTable);
+             PreparedStatement ins = c.prepareStatement(
+                "INSERT INTO " + newTable + "(id, session_id, player_uuid, check_id, vl, occurred_at, verbose, verbose_format, metadata) "
+                        + "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)");
+             ResultSet rs = sel.executeQuery()) {
+            int batched = 0;
+            while (rs.next()) {
+                long occurred = rs.getLong("occurred_at");
+                UUID newId = UuidV7.fromTimestampMs(occurred);
+                ins.setBytes(1, UuidCodec.toBytes(newId));
+                ins.setBytes(2, rs.getBytes("session_id"));
+                ins.setBytes(3, rs.getBytes("player_uuid"));
+                ins.setInt(4, rs.getInt("check_id"));
+                ins.setDouble(5, rs.getDouble("vl"));
+                ins.setLong(6, occurred);
+                ins.setString(7, rs.getString("verbose"));
+                ins.setInt(8, rs.getInt("verbose_format"));
+                ins.setString(9, rs.getString("metadata"));
+                ins.addBatch();
+                if (++batched % 1024 == 0) ins.executeBatch();
+            }
+            ins.executeBatch();
+        }
+
+        // Atomic multi-table swap: oldTable → backup AND newTable → oldTable
+        // happen as one operation. Crash during this statement → both rename
+        // ops abort, both tables still exist with their original names.
+        try (Statement s = c.createStatement()) {
+            s.executeUpdate("RENAME TABLE " + oldTable + " TO " + backupTable + ", "
+                    + newTable + " TO " + oldTable);
+            // Best-effort drop the backup on the happy path. If we crash
+            // between the rename and this drop, the early-return branch up
+            // top will pick it up on the next boot.
+            s.executeUpdate("DROP TABLE IF EXISTS " + backupTable);
+        }
+    }
+
+    private static boolean violationsIdIsBinary16(Connection c, String table) throws SQLException {
+        try (PreparedStatement ps = c.prepareStatement(
+                "SELECT DATA_TYPE FROM INFORMATION_SCHEMA.COLUMNS "
+                        + "WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = ? AND COLUMN_NAME = 'id'")) {
+            ps.setString(1, table);
+            try (ResultSet rs = ps.executeQuery()) {
+                if (!rs.next()) return false;
+                return "binary".equalsIgnoreCase(rs.getString(1));
+            }
         }
     }
 }

--- a/grim-internal/src/main/java/ac/grim/grimac/internal/storage/backend/mysql/MysqlSchema.java
+++ b/grim-internal/src/main/java/ac/grim/grimac/internal/storage/backend/mysql/MysqlSchema.java
@@ -74,7 +74,7 @@ public final class MysqlSchema {
                     + "; refusing to downgrade. Roll Grim forward.");
         }
 
-        // Forward migrations — additive only.
+        // Forward migrations.
         if (existing < 6) migrateV5ToV6(c, t);
         if (existing < 7) migrateV6ToV7(c, t);
         if (existing < 8) migrateV7ToV8(c, t, dialect);
@@ -152,7 +152,8 @@ public final class MysqlSchema {
      * (the function is Postgres 18+ only and not portable here), so this
      * does the same rebuild dance as the SQLite migration: create the new
      * table, stream rows out, mint UUIDv7s in Java from each row's
-     * {@code occurred_at}, bulk-insert into the new table, swap names.
+     * {@code occurred_at} and old numeric id, bulk-insert into the new table,
+     * swap names.
      */
     private static void migrateV8ToV9(Connection c, TableNames t) throws SQLException {
         String oldTable = t.violations();
@@ -186,13 +187,13 @@ public final class MysqlSchema {
                     + "verbose MEDIUMTEXT, "
                     + "verbose_format INT NOT NULL DEFAULT 0, "
                     + "metadata MEDIUMTEXT, "
-                    + "INDEX idx_" + oldTable + "_session_time (session_id, occurred_at), "
+                    + "INDEX idx_" + oldTable + "_session_time (session_id, occurred_at, id), "
                     + "INDEX idx_" + oldTable + "_player (player_uuid)"
                     + ") ENGINE=InnoDB DEFAULT CHARSET=utf8mb4");
         }
 
         try (PreparedStatement sel = c.prepareStatement(
-                "SELECT session_id, player_uuid, check_id, vl, occurred_at, verbose, verbose_format, metadata "
+                "SELECT id, session_id, player_uuid, check_id, vl, occurred_at, verbose, verbose_format, metadata "
                         + "FROM " + oldTable);
              PreparedStatement ins = c.prepareStatement(
                 "INSERT INTO " + newTable + "(id, session_id, player_uuid, check_id, vl, occurred_at, verbose, verbose_format, metadata) "
@@ -201,7 +202,7 @@ public final class MysqlSchema {
             int batched = 0;
             while (rs.next()) {
                 long occurred = rs.getLong("occurred_at");
-                UUID newId = UuidV7.fromTimestampMs(occurred);
+                UUID newId = UuidV7.fromTimestampMs(occurred, rs.getLong("id"));
                 ins.setBytes(1, UuidCodec.toBytes(newId));
                 ins.setBytes(2, rs.getBytes("session_id"));
                 ins.setBytes(3, rs.getBytes("player_uuid"));

--- a/grim-internal/src/main/java/ac/grim/grimac/internal/storage/backend/postgres/PostgresBackend.java
+++ b/grim-internal/src/main/java/ac/grim/grimac/internal/storage/backend/postgres/PostgresBackend.java
@@ -25,6 +25,7 @@ import ac.grim.grimac.api.storage.query.Page;
 import ac.grim.grimac.api.storage.query.Queries;
 import ac.grim.grimac.api.storage.query.Query;
 import ac.grim.grimac.internal.storage.util.UuidCodec;
+import ac.grim.grimac.internal.storage.util.UuidV7;
 import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
 
@@ -75,8 +76,8 @@ public final class PostgresBackend implements Backend {
         this.config = config;
         TableNames t = config.tableNames();
         this.insertViolations =
-                "INSERT INTO " + quoteId(t.violations()) + "(session_id, player_uuid, check_id, vl, occurred_at, \"verbose\", verbose_format) "
-                        + "VALUES (?, ?, ?, ?, ?, ?, ?)";
+                "INSERT INTO " + quoteId(t.violations()) + "(id, session_id, player_uuid, check_id, vl, occurred_at, \"verbose\", verbose_format) "
+                        + "VALUES (?, ?, ?, ?, ?, ?, ?, ?)";
         this.upsertSessions =
                 "INSERT INTO " + quoteId(t.sessions()) + "(session_id, player_uuid, server_name, started_at, last_activity, closed_at, "
                         + "grim_version, client_brand, client_version_pvn, server_version, replay_clips_json) "
@@ -247,13 +248,15 @@ public final class PostgresBackend implements Backend {
         @Override protected String categoryId() { return "violation"; }
         @Override
         protected void bind(PreparedStatement ps, ViolationEvent v) throws SQLException {
-            ps.setBytes(1, UuidCodec.toBytes(v.sessionId()));
-            ps.setBytes(2, UuidCodec.toBytes(v.playerUuid()));
-            ps.setInt(3, v.checkId());
-            ps.setDouble(4, v.vl());
-            ps.setLong(5, v.occurredEpochMs());
-            ps.setString(6, v.verbose());
-            ps.setInt(7, v.verboseFormat().code());
+            UUID id = v.id() != null ? v.id() : UuidV7.next();
+            ps.setBytes(1, UuidCodec.toBytes(id));
+            ps.setBytes(2, UuidCodec.toBytes(v.sessionId()));
+            ps.setBytes(3, UuidCodec.toBytes(v.playerUuid()));
+            ps.setInt(4, v.checkId());
+            ps.setDouble(5, v.vl());
+            ps.setLong(6, v.occurredEpochMs());
+            ps.setString(7, v.verbose());
+            ps.setInt(8, v.verboseFormat().code());
         }
     }
 
@@ -333,13 +336,14 @@ public final class PostgresBackend implements Backend {
     private void writeViolationRecords(List<ViolationRecord> rows) throws SQLException {
         try (PreparedStatement ps = writeConn.prepareStatement(insertViolations)) {
             for (ViolationRecord v : rows) {
-                ps.setBytes(1, UuidCodec.toBytes(v.sessionId()));
-                ps.setBytes(2, UuidCodec.toBytes(v.playerUuid()));
-                ps.setInt(3, v.checkId());
-                ps.setDouble(4, v.vl());
-                ps.setLong(5, v.occurredEpochMs());
-                ps.setString(6, v.verbose());
-                ps.setInt(7, v.verboseFormat().code());
+                ps.setBytes(1, UuidCodec.toBytes(v.id()));
+                ps.setBytes(2, UuidCodec.toBytes(v.sessionId()));
+                ps.setBytes(3, UuidCodec.toBytes(v.playerUuid()));
+                ps.setInt(4, v.checkId());
+                ps.setDouble(5, v.vl());
+                ps.setLong(6, v.occurredEpochMs());
+                ps.setString(7, v.verbose());
+                ps.setInt(8, v.verboseFormat().code());
                 ps.addBatch();
             }
             ps.executeBatch();
@@ -457,8 +461,12 @@ public final class PostgresBackend implements Backend {
     }
 
     private Page<ViolationRecord> listViolationsInSession(Connection c, Queries.ListViolationsInSession q) throws SQLException {
+        // Order by (occurred_at, id) — id is wall-clock at mint time and can drift
+        // from event time when callers pre-set event.id(), when ring slots sit
+        // before the sink runs, or when bulkImport carries through original ids.
+        // Id stays as the tiebreaker for same-ms bursts.
         long lastOccurred = decodeViolationOccurredCursor(q.cursor(), Long.MIN_VALUE);
-        long lastId = decodeViolationIdCursor(q.cursor());
+        byte[] lastId = decodeViolationIdCursor(q.cursor());
         try (PreparedStatement ps = c.prepareStatement(
                 "SELECT id, session_id, player_uuid, check_id, vl, occurred_at, \"verbose\", verbose_format "
                         + "FROM " + quoteId(config.tableNames().violations()) + " "
@@ -468,7 +476,7 @@ public final class PostgresBackend implements Backend {
             ps.setBytes(1, UuidCodec.toBytes(q.sessionId()));
             ps.setLong(2, lastOccurred);
             ps.setLong(3, lastOccurred);
-            ps.setLong(4, lastId);
+            ps.setBytes(4, lastId);
             ps.setInt(5, q.pageSize() + 1);
             try (ResultSet rs = ps.executeQuery()) {
                 List<ViolationRecord> out = new ArrayList<>();
@@ -570,7 +578,7 @@ public final class PostgresBackend implements Backend {
 
     private static ViolationRecord mapViolation(ResultSet rs) throws SQLException {
         return new ViolationRecord(
-                rs.getLong("id"),
+                UuidCodec.fromBytes(rs.getBytes("id")),
                 UuidCodec.fromBytes(rs.getBytes("session_id")),
                 UuidCodec.fromBytes(rs.getBytes("player_uuid")),
                 rs.getInt("check_id"),
@@ -733,24 +741,24 @@ public final class PostgresBackend implements Backend {
         return out;
     }
 
-    private static Cursor encodeViolationCursor(long occurred, long id) {
-        return new Cursor("v:" + occurred + ":" + id);
+    private static Cursor encodeViolationCursor(long occurredAt, UUID id) {
+        return new Cursor("v:" + occurredAt + ":" + id);
     }
 
     private static long decodeViolationOccurredCursor(Cursor c, long defaultVal) {
         if (c == null) return defaultVal;
-        String[] parts = c.token().split(":");
-        if (parts.length < 3) return defaultVal;
+        String[] parts = c.token().split(":", 3);
+        if (parts.length < 3 || !"v".equals(parts[0])) return defaultVal;
         try { return Long.parseLong(parts[1]); }
         catch (NumberFormatException e) { return defaultVal; }
     }
 
-    private static long decodeViolationIdCursor(Cursor c) {
-        if (c == null) return Long.MIN_VALUE;
-        String[] parts = c.token().split(":");
-        if (parts.length < 3) return Long.MIN_VALUE;
-        try { return Long.parseLong(parts[2]); }
-        catch (NumberFormatException e) { return Long.MIN_VALUE; }
+    private static byte[] decodeViolationIdCursor(Cursor c) {
+        if (c == null) return new byte[16];
+        String[] parts = c.token().split(":", 3);
+        if (parts.length < 3 || !"v".equals(parts[0])) return new byte[16];
+        try { return UuidCodec.toBytes(UUID.fromString(parts[2])); }
+        catch (IllegalArgumentException e) { return new byte[16]; }
     }
 
     @ApiStatus.Internal

--- a/grim-internal/src/main/java/ac/grim/grimac/internal/storage/backend/postgres/PostgresBackend.java
+++ b/grim-internal/src/main/java/ac/grim/grimac/internal/storage/backend/postgres/PostgresBackend.java
@@ -25,7 +25,6 @@ import ac.grim.grimac.api.storage.query.Page;
 import ac.grim.grimac.api.storage.query.Queries;
 import ac.grim.grimac.api.storage.query.Query;
 import ac.grim.grimac.internal.storage.util.UuidCodec;
-import ac.grim.grimac.internal.storage.util.UuidV7;
 import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
 
@@ -248,7 +247,7 @@ public final class PostgresBackend implements Backend {
         @Override protected String categoryId() { return "violation"; }
         @Override
         protected void bind(PreparedStatement ps, ViolationEvent v) throws SQLException {
-            UUID id = v.id() != null ? v.id() : UuidV7.next();
+            UUID id = v.id();
             ps.setBytes(1, UuidCodec.toBytes(id));
             ps.setBytes(2, UuidCodec.toBytes(v.sessionId()));
             ps.setBytes(3, UuidCodec.toBytes(v.playerUuid()));

--- a/grim-internal/src/main/java/ac/grim/grimac/internal/storage/backend/postgres/PostgresBackend.java
+++ b/grim-internal/src/main/java/ac/grim/grimac/internal/storage/backend/postgres/PostgresBackend.java
@@ -51,7 +51,7 @@ import static ac.grim.grimac.internal.storage.backend.postgres.PostgresSchema.qu
  *   <li>UUIDs stored as {@code BYTEA} (Postgres's native byte array). The
  *       alternative was the dedicated {@code UUID} type, but that would
  *       require a different binding path than the rest of the backends.</li>
- *   <li>Auto-increment via {@code BIGSERIAL} instead of {@code AUTO_INCREMENT}.</li>
+ *   <li>Violation ids are UUIDv7 bytes generated before insert.</li>
  *   <li>All identifiers quoted with {@code "…"} so custom
  *       {@link TableNames} that happen to overlap a Postgres reserved word
  *       (e.g. {@code "user"}) still work.</li>

--- a/grim-internal/src/main/java/ac/grim/grimac/internal/storage/backend/postgres/PostgresSchema.java
+++ b/grim-internal/src/main/java/ac/grim/grimac/internal/storage/backend/postgres/PostgresSchema.java
@@ -142,11 +142,7 @@ public final class PostgresSchema {
             s.executeUpdate("CREATE INDEX " + quoteId("idx_" + t.sessions() + "_player_started")
                     + " ON " + quoteId(t.sessions()) + " (player_uuid, started_at DESC)");
 
-            // v8: id is a UUIDv7 stored as BYTEA. Producer-side minted so
-            // multiple JVMs sharing one Postgres mint ids without coordinating
-            // through the BIGSERIAL sequence. The timestamp prefix keeps the
-            // PK B-tree append-friendly (same locality property BIGSERIAL gave
-            // us).
+            // UUIDv7 ids preserve write locality without a database sequence.
             s.executeUpdate("CREATE TABLE " + quoteId(t.violations()) + " ("
                     + "id BYTEA PRIMARY KEY, "
                     + "session_id BYTEA NOT NULL, "

--- a/grim-internal/src/main/java/ac/grim/grimac/internal/storage/backend/postgres/PostgresSchema.java
+++ b/grim-internal/src/main/java/ac/grim/grimac/internal/storage/backend/postgres/PostgresSchema.java
@@ -157,7 +157,7 @@ public final class PostgresSchema {
                     + "metadata TEXT"
                     + ")");
             s.executeUpdate("CREATE INDEX " + quoteId("idx_" + t.violations() + "_session_time")
-                    + " ON " + quoteId(t.violations()) + " (session_id, occurred_at)");
+                    + " ON " + quoteId(t.violations()) + " (session_id, occurred_at, id)");
             s.executeUpdate("CREATE INDEX " + quoteId("idx_" + t.violations() + "_player")
                     + " ON " + quoteId(t.violations()) + " (player_uuid)");
 
@@ -177,7 +177,8 @@ public final class PostgresSchema {
      * {@code BYTEA} carrying a UUIDv7. Postgres &lt;18 has no native uuidv7()
      * generator, so this does the same rebuild dance as the other backends:
      * create a new table, stream rows out, mint UUIDv7 from each row's
-     * {@code occurred_at} in Java, bulk-insert into the new table, swap names.
+     * {@code occurred_at} and old numeric id in Java, bulk-insert into the new
+     * table, swap names.
      *
      * <p>Also drops the BIGSERIAL sequence (the old {@code id} column's
      * default), which Postgres leaves behind when the table is dropped.
@@ -212,7 +213,7 @@ public final class PostgresSchema {
             }
 
             try (PreparedStatement sel = c.prepareStatement(
-                    "SELECT session_id, player_uuid, check_id, vl, occurred_at, \"verbose\", verbose_format, metadata "
+                    "SELECT id, session_id, player_uuid, check_id, vl, occurred_at, \"verbose\", verbose_format, metadata "
                             + "FROM " + quoteId(oldTable));
                  PreparedStatement ins = c.prepareStatement(
                     "INSERT INTO " + quoteId(newTable) + "(id, session_id, player_uuid, check_id, vl, occurred_at, \"verbose\", verbose_format, metadata) "
@@ -221,7 +222,7 @@ public final class PostgresSchema {
                 int batched = 0;
                 while (rs.next()) {
                     long occurred = rs.getLong("occurred_at");
-                    UUID newId = UuidV7.fromTimestampMs(occurred);
+                    UUID newId = UuidV7.fromTimestampMs(occurred, rs.getLong("id"));
                     ins.setBytes(1, UuidCodec.toBytes(newId));
                     ins.setBytes(2, rs.getBytes("session_id"));
                     ins.setBytes(3, rs.getBytes("player_uuid"));
@@ -243,7 +244,7 @@ public final class PostgresSchema {
                 s.executeUpdate("DROP TABLE " + quoteId(oldTable) + " CASCADE");
                 s.executeUpdate("ALTER TABLE " + quoteId(newTable) + " RENAME TO " + quoteId(oldTable));
                 s.executeUpdate("CREATE INDEX " + quoteId("idx_" + oldTable + "_session_time")
-                        + " ON " + quoteId(oldTable) + " (session_id, occurred_at)");
+                        + " ON " + quoteId(oldTable) + " (session_id, occurred_at, id)");
                 s.executeUpdate("CREATE INDEX " + quoteId("idx_" + oldTable + "_player")
                         + " ON " + quoteId(oldTable) + " (player_uuid)");
             }

--- a/grim-internal/src/main/java/ac/grim/grimac/internal/storage/backend/postgres/PostgresSchema.java
+++ b/grim-internal/src/main/java/ac/grim/grimac/internal/storage/backend/postgres/PostgresSchema.java
@@ -2,6 +2,8 @@ package ac.grim.grimac.internal.storage.backend.postgres;
 
 import ac.grim.grimac.api.storage.config.TableNames;
 import ac.grim.grimac.internal.storage.checks.LegacyKeyRenames;
+import ac.grim.grimac.internal.storage.util.UuidCodec;
+import ac.grim.grimac.internal.storage.util.UuidV7;
 import org.jetbrains.annotations.ApiStatus;
 
 import java.sql.Connection;
@@ -10,6 +12,7 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
 import java.util.Map;
+import java.util.UUID;
 
 /**
  * Postgres 14+ schema for the Postgres backend. Born at the v5 baseline — see
@@ -19,7 +22,7 @@ import java.util.Map;
 @ApiStatus.Internal
 public final class PostgresSchema {
 
-    public static final int CURRENT_VERSION = 7;
+    public static final int CURRENT_VERSION = 8;
 
     private PostgresSchema() {}
 
@@ -58,6 +61,7 @@ public final class PostgresSchema {
 
         if (existing < 6) migrateV5ToV6(c, t);
         if (existing < 7) migrateV6ToV7(c, t);
+        if (existing < 8) migrateV7ToV8(c, t);
 
         if (existing < CURRENT_VERSION) {
             try (PreparedStatement ps = c.prepareStatement(
@@ -138,8 +142,13 @@ public final class PostgresSchema {
             s.executeUpdate("CREATE INDEX " + quoteId("idx_" + t.sessions() + "_player_started")
                     + " ON " + quoteId(t.sessions()) + " (player_uuid, started_at DESC)");
 
+            // v8: id is a UUIDv7 stored as BYTEA. Producer-side minted so
+            // multiple JVMs sharing one Postgres mint ids without coordinating
+            // through the BIGSERIAL sequence. The timestamp prefix keeps the
+            // PK B-tree append-friendly (same locality property BIGSERIAL gave
+            // us).
             s.executeUpdate("CREATE TABLE " + quoteId(t.violations()) + " ("
-                    + "id BIGSERIAL PRIMARY KEY, "
+                    + "id BYTEA PRIMARY KEY, "
                     + "session_id BYTEA NOT NULL, "
                     + "player_uuid BYTEA NOT NULL, "
                     + "check_id INTEGER NOT NULL, "
@@ -164,6 +173,91 @@ public final class PostgresSchema {
                     + "updated_at BIGINT NOT NULL, "
                     + "PRIMARY KEY (scope, scope_key, key)"
                     + ")");
+        }
+    }
+
+    /**
+     * v7 → v8: violation {@code id} type changes from {@code BIGSERIAL} to
+     * {@code BYTEA} carrying a UUIDv7. Postgres &lt;18 has no native uuidv7()
+     * generator, so this does the same rebuild dance as the other backends:
+     * create a new table, stream rows out, mint UUIDv7 from each row's
+     * {@code occurred_at} in Java, bulk-insert into the new table, swap names.
+     *
+     * <p>Also drops the BIGSERIAL sequence (the old {@code id} column's
+     * default), which Postgres leaves behind when the table is dropped.
+     */
+    private static void migrateV7ToV8(Connection c, TableNames t) throws SQLException {
+        String oldTable = t.violations();
+        String newTable = t.violations() + "_uuid_v7_tmp";
+
+        // Postgres has transactional DDL: run the whole rewrite as one
+        // transaction so a crash anywhere short of COMMIT rolls back to v7
+        // shape with the canonical data untouched. ensureInitialized opens
+        // the connection with autocommit on by default; flip it for this
+        // migration only.
+        boolean priorAutoCommit = c.getAutoCommit();
+        c.setAutoCommit(false);
+        try {
+            try (Statement s = c.createStatement()) {
+                // Clean tmp from any prior aborted run — same transaction, so
+                // safe even if the canonical oldTable is the only data copy.
+                s.executeUpdate("DROP TABLE IF EXISTS " + quoteId(newTable));
+                s.executeUpdate("CREATE TABLE " + quoteId(newTable) + " ("
+                        + "id BYTEA PRIMARY KEY, "
+                        + "session_id BYTEA NOT NULL, "
+                        + "player_uuid BYTEA NOT NULL, "
+                        + "check_id INTEGER NOT NULL, "
+                        + "vl DOUBLE PRECISION NOT NULL, "
+                        + "occurred_at BIGINT NOT NULL, "
+                        + "\"verbose\" TEXT, "
+                        + "verbose_format INTEGER NOT NULL DEFAULT 0, "
+                        + "metadata TEXT"
+                        + ")");
+            }
+
+            try (PreparedStatement sel = c.prepareStatement(
+                    "SELECT session_id, player_uuid, check_id, vl, occurred_at, \"verbose\", verbose_format, metadata "
+                            + "FROM " + quoteId(oldTable));
+                 PreparedStatement ins = c.prepareStatement(
+                    "INSERT INTO " + quoteId(newTable) + "(id, session_id, player_uuid, check_id, vl, occurred_at, \"verbose\", verbose_format, metadata) "
+                            + "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)");
+                 ResultSet rs = sel.executeQuery()) {
+                int batched = 0;
+                while (rs.next()) {
+                    long occurred = rs.getLong("occurred_at");
+                    UUID newId = UuidV7.fromTimestampMs(occurred);
+                    ins.setBytes(1, UuidCodec.toBytes(newId));
+                    ins.setBytes(2, rs.getBytes("session_id"));
+                    ins.setBytes(3, rs.getBytes("player_uuid"));
+                    ins.setInt(4, rs.getInt("check_id"));
+                    ins.setDouble(5, rs.getDouble("vl"));
+                    ins.setLong(6, occurred);
+                    ins.setString(7, rs.getString("verbose"));
+                    ins.setInt(8, rs.getInt("verbose_format"));
+                    ins.setString(9, rs.getString("metadata"));
+                    ins.addBatch();
+                    if (++batched % 1024 == 0) ins.executeBatch();
+                }
+                ins.executeBatch();
+            }
+
+            try (Statement s = c.createStatement()) {
+                // DROP CASCADE so the BIGSERIAL sequence on id goes with the
+                // table — Postgres won't auto-drop it otherwise.
+                s.executeUpdate("DROP TABLE " + quoteId(oldTable) + " CASCADE");
+                s.executeUpdate("ALTER TABLE " + quoteId(newTable) + " RENAME TO " + quoteId(oldTable));
+                s.executeUpdate("CREATE INDEX " + quoteId("idx_" + oldTable + "_session_time")
+                        + " ON " + quoteId(oldTable) + " (session_id, occurred_at)");
+                s.executeUpdate("CREATE INDEX " + quoteId("idx_" + oldTable + "_player")
+                        + " ON " + quoteId(oldTable) + " (player_uuid)");
+            }
+
+            c.commit();
+        } catch (SQLException e) {
+            try { c.rollback(); } catch (SQLException ignored) {}
+            throw e;
+        } finally {
+            c.setAutoCommit(priorAutoCommit);
         }
     }
 

--- a/grim-internal/src/main/java/ac/grim/grimac/internal/storage/backend/redis/RedisBackend.java
+++ b/grim-internal/src/main/java/ac/grim/grimac/internal/storage/backend/redis/RedisBackend.java
@@ -254,7 +254,7 @@ public final class RedisBackend implements Backend {
 
     private void writeViolation(ViolationEvent v, long sequence, boolean endOfBatch) throws BackendException {
         try (Jedis j = pool.getResource()) {
-            UUID id = v.id() != null ? v.id() : UuidV7.next();
+            UUID id = v.id();
             String idHex = hex(id);
             String sessionHex = hex(v.sessionId());
             String playerHex = hex(v.playerUuid());

--- a/grim-internal/src/main/java/ac/grim/grimac/internal/storage/backend/redis/RedisBackend.java
+++ b/grim-internal/src/main/java/ac/grim/grimac/internal/storage/backend/redis/RedisBackend.java
@@ -26,6 +26,7 @@ import ac.grim.grimac.api.storage.query.Page;
 import ac.grim.grimac.api.storage.query.Queries;
 import ac.grim.grimac.api.storage.query.Query;
 import ac.grim.grimac.internal.storage.util.UuidCodec;
+import ac.grim.grimac.internal.storage.util.UuidV7;
 import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
 import redis.clients.jedis.DefaultJedisClientConfig;
@@ -73,17 +74,22 @@ import java.util.logging.Logger;
  *   <li>{@code <prefix><players>:by-name-lower:<lc-name>}: string → current uuid-hex.</li>
  *   <li>{@code <prefix><sessions>:<session-hex>}: per-session hash.</li>
  *   <li>{@code <prefix><sessions>:by-player:<uuid-hex>}: ZSET, score=startedAt, member=session-hex.</li>
- *   <li>{@code <prefix><violations>:<id>}: per-violation hash.</li>
- *   <li>{@code <prefix><violations>:by-session:<session-hex>}: ZSET, score=occurredAt, member=violationId.</li>
- *   <li>{@code <prefix><violations>:by-player:<uuid-hex>}: ZSET, score=occurredAt, member=violationId.</li>
+ *   <li>{@code <prefix><violations>:<uuid-hex>}: per-violation hash.</li>
+ *   <li>{@code <prefix><violations>:by-session:<session-hex>}: ZSET, score=occurredAt, member=uuid-hex.</li>
+ *   <li>{@code <prefix><violations>:by-player:<uuid-hex>}: ZSET, score=occurredAt, member=uuid-hex.</li>
  *   <li>{@code <prefix><settings>:<scope>:<scope_key>:<key>}: hash holding value+updated_at.</li>
  * </ul>
- * Violation ids are monotonic longs minted via {@code HINCRBY meta violation_id_seq 1}.
+ * Violation ids are UUIDv7 minted producer-side by {@code ViolationSinkImpl};
+ * the timestamp prefix means they're k-sortable and the lookup keys stay
+ * append-friendly to Redis's hash index.
  */
 @ApiStatus.Internal
 public final class RedisBackend implements Backend {
 
     public static final String ID = "redis";
+
+    /** Bumped on every breaking shape change. {@code migrateSchema} walks forward steps. */
+    static final int CURRENT_SCHEMA_VERSION = 6;
 
     private final RedisBackendConfig config;
     private JedisPool pool;
@@ -133,9 +139,18 @@ public final class RedisBackend implements Backend {
             poolConfig.setMaxTotal(16);
             this.pool = new JedisPool(poolConfig, new HostAndPort(config.host(), config.port()), b.build());
             try (Jedis j = pool.getResource()) {
-                j.hsetnx(metaKey(), "schema_version", "5");
-                j.hsetnx(metaKey(), "grim_core_version", "phase1");
-                j.hsetnx(metaKey(), "violation_id_seq", "0");
+                String existingVer = j.hget(metaKey(), "schema_version");
+                if (existingVer == null) {
+                    // Fresh DB — stamp the current version and we're done.
+                    j.hset(metaKey(), Map.of(
+                            "schema_version", Integer.toString(CURRENT_SCHEMA_VERSION),
+                            "grim_core_version", "phase1"));
+                } else {
+                    int existing;
+                    try { existing = Integer.parseInt(existingVer); }
+                    catch (NumberFormatException nfe) { existing = 0; }
+                    if (existing < CURRENT_SCHEMA_VERSION) migrateSchema(j, existing);
+                }
             }
             if (config.warnOnHistory()) {
                 // Pre-format the String so java.util.logging's MessageFormat
@@ -149,6 +164,68 @@ public final class RedisBackend implements Backend {
         } catch (RuntimeException e) {
             throw new BackendException("failed to initialise Redis backend", e);
         }
+    }
+
+    /**
+     * Forward-only Redis schema migration. {@code v5} ids were monotonic
+     * longs minted via {@code HINCRBY meta violation_id_seq 1}; {@code v6}
+     * makes them UUIDv7s minted producer-side. Each legacy violation row
+     * gets a synthesised UUIDv7 derived from its {@code occurred_at}, and
+     * the per-session / per-player ZSETs are rewritten with the new
+     * member ids.
+     */
+    private void migrateSchema(Jedis j, int existing) {
+        if (existing < 6) migrateV5ToV6(j);
+        j.hset(metaKey(), "schema_version", Integer.toString(CURRENT_SCHEMA_VERSION));
+        j.hdel(metaKey(), "violation_id_seq");
+    }
+
+    private void migrateV5ToV6(Jedis j) {
+        logger.info("[grim-datastore] migrating Redis violations id long→UUIDv7 …");
+        String prefix = tableKey(config.tableNames().violations()) + ":";
+        String pattern = prefix + "*";
+        ScanParams sp = new ScanParams().match(pattern).count(500);
+        String cursor = ScanParams.SCAN_POINTER_START;
+        long migrated = 0;
+        do {
+            redis.clients.jedis.resps.ScanResult<String> res = j.scan(cursor, sp);
+            cursor = res.getCursor();
+            for (String oldKey : res.getResult()) {
+                // Skip the secondary indexes — only direct violation hashes
+                // need rewriting.
+                if (oldKey.contains(":by-session:") || oldKey.contains(":by-player:")) continue;
+                Map<String, String> h = j.hgetAll(oldKey);
+                if (h.isEmpty()) continue;
+                String oldId = h.get("id");
+                if (oldId == null) continue;
+                // Already-migrated rows have a UUID-shaped id (32 hex chars).
+                if (oldId.length() == 32 && oldId.matches("[0-9a-fA-F]+")) continue;
+                String occurredStr = h.get("occurred_at");
+                long occurred = occurredStr == null ? 0L : Long.parseLong(occurredStr);
+                UUID newId = UuidV7.fromTimestampMs(occurred);
+                String newIdHex = hex(newId);
+                String newKey = prefix + newIdHex;
+                String sessionHex = h.get("session_id");
+                String playerHex = h.get("player_uuid");
+                h.put("id", newIdHex);
+                Pipeline p = j.pipelined();
+                p.hset(newKey, h);
+                p.del(oldKey);
+                if (sessionHex != null) {
+                    String zSession = tableKey(config.tableNames().violations()) + ":by-session:" + sessionHex;
+                    p.zrem(zSession, oldId);
+                    p.zadd(zSession, occurred, newIdHex);
+                }
+                if (playerHex != null) {
+                    String zPlayer = tableKey(config.tableNames().violations()) + ":by-player:" + playerHex;
+                    p.zrem(zPlayer, oldId);
+                    p.zadd(zPlayer, occurred, newIdHex);
+                }
+                p.sync();
+                migrated++;
+            }
+        } while (!ScanParams.SCAN_POINTER_START.equals(cursor));
+        logger.info("[grim-datastore] migrated " + migrated + " violation rows to UUIDv7 id");
     }
 
     @Override public void flush() {}
@@ -177,14 +254,15 @@ public final class RedisBackend implements Backend {
 
     private void writeViolation(ViolationEvent v, long sequence, boolean endOfBatch) throws BackendException {
         try (Jedis j = pool.getResource()) {
-            long id = j.hincrBy(metaKey(), "violation_id_seq", 1);
-            String hex = hex(v.sessionId());
-            String phex = hex(v.playerUuid());
-            String recordKey = tableKey(config.tableNames().violations()) + ":" + id;
+            UUID id = v.id() != null ? v.id() : UuidV7.next();
+            String idHex = hex(id);
+            String sessionHex = hex(v.sessionId());
+            String playerHex = hex(v.playerUuid());
+            String recordKey = tableKey(config.tableNames().violations()) + ":" + idHex;
             Map<String, String> h = new HashMap<>();
-            h.put("id", Long.toString(id));
-            h.put("session_id", hex);
-            h.put("player_uuid", phex);
+            h.put("id", idHex);
+            h.put("session_id", sessionHex);
+            h.put("player_uuid", playerHex);
             h.put("check_id", Integer.toString(v.checkId()));
             h.put("vl", Double.toString(v.vl()));
             h.put("occurred_at", Long.toString(v.occurredEpochMs()));
@@ -192,8 +270,8 @@ public final class RedisBackend implements Backend {
             h.put("verbose_format", Integer.toString(v.verboseFormat().code()));
             Pipeline p = j.pipelined();
             p.hset(recordKey, h);
-            p.zadd(tableKey(config.tableNames().violations()) + ":by-session:" + hex, v.occurredEpochMs(), Long.toString(id));
-            p.zadd(tableKey(config.tableNames().violations()) + ":by-player:" + phex, v.occurredEpochMs(), Long.toString(id));
+            p.zadd(tableKey(config.tableNames().violations()) + ":by-session:" + sessionHex, v.occurredEpochMs(), idHex);
+            p.zadd(tableKey(config.tableNames().violations()) + ":by-player:" + playerHex, v.occurredEpochMs(), idHex);
             p.sync();
         } catch (RuntimeException e) {
             throw new BackendException("violation write failed", e);
@@ -294,20 +372,16 @@ public final class RedisBackend implements Backend {
 
     private void bulkViolation(ViolationRecord v) {
         try (Jedis j = pool.getResource()) {
-            long id = v.id() > 0 ? v.id() : j.hincrBy(metaKey(), "violation_id_seq", 1);
-            // Keep the counter ahead of any operator-provided id so the next
-            // live write doesn't collide.
-            j.eval("if tonumber(redis.call('hget', KEYS[1], 'violation_id_seq') or '0') < tonumber(ARGV[1]) then "
-                    + "redis.call('hset', KEYS[1], 'violation_id_seq', ARGV[1]) end",
-                    Collections.singletonList(metaKey()),
-                    Collections.singletonList(Long.toString(id)));
-            String hex = hex(v.sessionId());
-            String phex = hex(v.playerUuid());
-            String key = tableKey(config.tableNames().violations()) + ":" + id;
+            // ViolationRecord.id is non-null by record contract — cross-backend
+            // bulkImport always carries an id through verbatim.
+            String idHex = hex(v.id());
+            String sessionHex = hex(v.sessionId());
+            String playerHex = hex(v.playerUuid());
+            String key = tableKey(config.tableNames().violations()) + ":" + idHex;
             Map<String, String> h = new HashMap<>();
-            h.put("id", Long.toString(id));
-            h.put("session_id", hex);
-            h.put("player_uuid", phex);
+            h.put("id", idHex);
+            h.put("session_id", sessionHex);
+            h.put("player_uuid", playerHex);
             h.put("check_id", Integer.toString(v.checkId()));
             h.put("vl", Double.toString(v.vl()));
             h.put("occurred_at", Long.toString(v.occurredEpochMs()));
@@ -315,8 +389,8 @@ public final class RedisBackend implements Backend {
             h.put("verbose_format", Integer.toString(v.verboseFormat().code()));
             Pipeline p = j.pipelined();
             p.hset(key, h);
-            p.zadd(tableKey(config.tableNames().violations()) + ":by-session:" + hex, v.occurredEpochMs(), Long.toString(id));
-            p.zadd(tableKey(config.tableNames().violations()) + ":by-player:" + phex, v.occurredEpochMs(), Long.toString(id));
+            p.zadd(tableKey(config.tableNames().violations()) + ":by-session:" + sessionHex, v.occurredEpochMs(), idHex);
+            p.zadd(tableKey(config.tableNames().violations()) + ":by-player:" + playerHex, v.occurredEpochMs(), idHex);
             p.sync();
         }
     }
@@ -426,17 +500,41 @@ public final class RedisBackend implements Backend {
     }
 
     private Page<ViolationRecord> listViolationsInSession(Jedis j, Queries.ListViolationsInSession q) {
-        long cursorOccurred = decodeViolationOccurredCursor(q.cursor(), Long.MIN_VALUE);
+        // ZSET score is occurred_at, member is the violation's UUIDv7 hex.
+        // Cursor carries both (score, id) so we can resume mid-burst: exclusive
+        // lower bound on score alone would skip every other row sharing the
+        // boundary score. Inclusive lower bound + in-client filter on (score,
+        // member) gets us back to (occurred_at, id) lexicographic ordering.
+        long cursorScore = decodeViolationOccurredCursor(q.cursor(), Long.MIN_VALUE);
+        UUID cursorId = decodeViolationIdCursor(q.cursor());
         String zsetKey = tableKey(config.tableNames().violations()) + ":by-session:" + hex(q.sessionId());
-        String min = q.cursor() == null ? "-inf" : "(" + cursorOccurred;
-        List<Tuple> members = j.zrangeByScoreWithScores(zsetKey, min, "+inf", 0, q.pageSize() + 1);
+        String min = cursorId == null ? "-inf" : Long.toString(cursorScore);
+        String cursorMemberHex = cursorId == null ? null : hex(cursorId);
+        // Fetch pageSize+1 *past* the cursor — but at the boundary score the
+        // ZSET may return rows we already shipped on the previous page, so we
+        // skip them in client until we move past (score, member). Worst case
+        // (huge same-score burst) is a couple extra ZRANGE calls; in practice
+        // bursts at a single ms are bounded by ring throughput.
         List<ViolationRecord> out = new ArrayList<>();
         boolean hasMore = false;
-        for (Tuple t : members) {
-            if (out.size() >= q.pageSize()) { hasMore = true; break; }
-            Map<String, String> h = j.hgetAll(tableKey(config.tableNames().violations()) + ":" + t.getElement());
-            if (h.isEmpty()) continue;
-            out.add(mapViolation(h));
+        boolean skipping = cursorId != null;
+        long offset = 0;
+        int wanted = q.pageSize() + 1;
+        while (out.size() < wanted) {
+            List<Tuple> members = j.zrangeByScoreWithScores(zsetKey, min, "+inf", (int) offset, wanted - out.size());
+            if (members.isEmpty()) break;
+            offset += members.size();
+            for (Tuple t : members) {
+                if (skipping) {
+                    if ((long) t.getScore() == cursorScore && t.getElement().compareTo(cursorMemberHex) <= 0) continue;
+                    skipping = false;
+                }
+                if (out.size() >= q.pageSize()) { hasMore = true; break; }
+                Map<String, String> h = j.hgetAll(tableKey(config.tableNames().violations()) + ":" + t.getElement());
+                if (h.isEmpty()) continue;
+                out.add(mapViolation(h));
+            }
+            if (hasMore || members.size() < wanted - out.size()) break;
         }
         Cursor next = null;
         if (hasMore && !out.isEmpty()) {
@@ -526,7 +624,7 @@ public final class RedisBackend implements Backend {
 
     private static ViolationRecord mapViolation(Map<String, String> h) {
         return new ViolationRecord(
-                Long.parseLong(h.get("id")),
+                fromHex(h.get("id")),
                 fromHex(h.get("session_id")),
                 fromHex(h.get("player_uuid")),
                 Integer.parseInt(h.get("check_id")),
@@ -786,16 +884,24 @@ public final class RedisBackend implements Backend {
         catch (NumberFormatException e) { return defaultVal; }
     }
 
-    private static Cursor encodeViolationCursor(long occurred, long id) {
-        return new Cursor("v:" + occurred + ":" + id);
+    private static Cursor encodeViolationCursor(long occurredAt, UUID id) {
+        return new Cursor("v:" + occurredAt + ":" + id);
     }
 
     private static long decodeViolationOccurredCursor(Cursor c, long defaultVal) {
         if (c == null) return defaultVal;
-        String[] parts = c.token().split(":");
-        if (parts.length < 3) return defaultVal;
+        String[] parts = c.token().split(":", 3);
+        if (parts.length < 3 || !"v".equals(parts[0])) return defaultVal;
         try { return Long.parseLong(parts[1]); }
         catch (NumberFormatException e) { return defaultVal; }
+    }
+
+    private static UUID decodeViolationIdCursor(Cursor c) {
+        if (c == null) return null;
+        String[] parts = c.token().split(":", 3);
+        if (parts.length < 3 || !"v".equals(parts[0])) return null;
+        try { return UUID.fromString(parts[2]); }
+        catch (IllegalArgumentException e) { return null; }
     }
 
     @ApiStatus.Internal

--- a/grim-internal/src/main/java/ac/grim/grimac/internal/storage/backend/redis/RedisBackend.java
+++ b/grim-internal/src/main/java/ac/grim/grimac/internal/storage/backend/redis/RedisBackend.java
@@ -79,9 +79,10 @@ import java.util.logging.Logger;
  *   <li>{@code <prefix><violations>:by-player:<uuid-hex>}: ZSET, score=occurredAt, member=uuid-hex.</li>
  *   <li>{@code <prefix><settings>:<scope>:<scope_key>:<key>}: hash holding value+updated_at.</li>
  * </ul>
- * Violation ids are UUIDv7 minted producer-side by {@code ViolationSinkImpl};
- * the timestamp prefix means they're k-sortable and the lookup keys stay
- * append-friendly to Redis's hash index.
+ * Violation ids are UUIDv7 minted producer-side by the default
+ * {@code DataStore.submit} path. The timestamp prefix keeps ids k-sortable;
+ * Redis pages violations by {@code occurred_at} score with id as the
+ * same-score tie-breaker.
  */
 @ApiStatus.Internal
 public final class RedisBackend implements Backend {
@@ -202,7 +203,10 @@ public final class RedisBackend implements Backend {
                 if (oldId.length() == 32 && oldId.matches("[0-9a-fA-F]+")) continue;
                 String occurredStr = h.get("occurred_at");
                 long occurred = occurredStr == null ? 0L : Long.parseLong(occurredStr);
-                UUID newId = UuidV7.fromTimestampMs(occurred);
+                long legacyId;
+                try { legacyId = Long.parseLong(oldId); }
+                catch (NumberFormatException ignored) { legacyId = 0L; }
+                UUID newId = UuidV7.fromTimestampMs(occurred, legacyId);
                 String newIdHex = hex(newId);
                 String newKey = prefix + newIdHex;
                 String sessionHex = h.get("session_id");

--- a/grim-internal/src/main/java/ac/grim/grimac/internal/storage/backend/sqlite/SqliteBackend.java
+++ b/grim-internal/src/main/java/ac/grim/grimac/internal/storage/backend/sqlite/SqliteBackend.java
@@ -28,6 +28,7 @@ import ac.grim.grimac.internal.storage.backend.sqlite.writers.SessionUpserter;
 import ac.grim.grimac.internal.storage.backend.sqlite.writers.SettingsUpserter;
 import ac.grim.grimac.internal.storage.backend.sqlite.writers.UpserterFactory;
 import ac.grim.grimac.internal.storage.util.UuidCodec;
+import ac.grim.grimac.internal.storage.util.UuidV7;
 import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
 
@@ -83,8 +84,8 @@ public final class SqliteBackend implements Backend {
         this.config = config;
         ac.grim.grimac.api.storage.config.TableNames t = config.tableNames();
         this.insertViolations =
-                "INSERT INTO " + t.violations() + "(session_id, player_uuid, check_id, vl, occurred_at, verbose, verbose_format) "
-                        + "VALUES (?, ?, ?, ?, ?, ?, ?)";
+                "INSERT INTO " + t.violations() + "(id, session_id, player_uuid, check_id, vl, occurred_at, verbose, verbose_format) "
+                        + "VALUES (?, ?, ?, ?, ?, ?, ?, ?)";
     }
 
     @Override public @NotNull String id() { return ID; }
@@ -420,13 +421,15 @@ public final class SqliteBackend implements Backend {
         @Override
         protected void bindOne(ViolationEvent v) throws SQLException {
             if (stmt == null) stmt = conn.prepareStatement(insertViolations);
-            stmt.setBytes(1, UuidCodec.toBytes(v.sessionId()));
-            stmt.setBytes(2, UuidCodec.toBytes(v.playerUuid()));
-            stmt.setInt(3, v.checkId());
-            stmt.setDouble(4, v.vl());
-            stmt.setLong(5, v.occurredEpochMs());
-            stmt.setString(6, v.verbose());
-            stmt.setInt(7, v.verboseFormat().code());
+            UUID id = v.id() != null ? v.id() : UuidV7.next();
+            stmt.setBytes(1, UuidCodec.toBytes(id));
+            stmt.setBytes(2, UuidCodec.toBytes(v.sessionId()));
+            stmt.setBytes(3, UuidCodec.toBytes(v.playerUuid()));
+            stmt.setInt(4, v.checkId());
+            stmt.setDouble(5, v.vl());
+            stmt.setLong(6, v.occurredEpochMs());
+            stmt.setString(7, v.verbose());
+            stmt.setInt(8, v.verboseFormat().code());
             stmt.addBatch();
         }
 
@@ -555,13 +558,14 @@ public final class SqliteBackend implements Backend {
     private void writeViolationRecords(List<ViolationRecord> rows) throws SQLException {
         try (PreparedStatement ps = writeConn.prepareStatement(insertViolations)) {
             for (ViolationRecord v : rows) {
-                ps.setBytes(1, UuidCodec.toBytes(v.sessionId()));
-                ps.setBytes(2, UuidCodec.toBytes(v.playerUuid()));
-                ps.setInt(3, v.checkId());
-                ps.setDouble(4, v.vl());
-                ps.setLong(5, v.occurredEpochMs());
-                ps.setString(6, v.verbose());
-                ps.setInt(7, v.verboseFormat().code());
+                ps.setBytes(1, UuidCodec.toBytes(v.id()));
+                ps.setBytes(2, UuidCodec.toBytes(v.sessionId()));
+                ps.setBytes(3, UuidCodec.toBytes(v.playerUuid()));
+                ps.setInt(4, v.checkId());
+                ps.setDouble(5, v.vl());
+                ps.setLong(6, v.occurredEpochMs());
+                ps.setString(7, v.verbose());
+                ps.setInt(8, v.verboseFormat().code());
                 ps.addBatch();
             }
             ps.executeBatch();
@@ -679,8 +683,12 @@ public final class SqliteBackend implements Backend {
     }
 
     private Page<ViolationRecord> listViolationsInSession(Connection c, Queries.ListViolationsInSession q) throws SQLException {
+        // Order by (occurred_at, id) — id is wall-clock-at-mint, which can drift
+        // from event time when callers pre-set event.id(), when ring-buffer slots
+        // sit before the sink runs, or when bulkImport carries through original
+        // ids. Id stays as the tiebreaker for same-ms bursts.
         long lastOccurred = decodeViolationOccurredCursor(q.cursor(), Long.MIN_VALUE);
-        long lastId = decodeViolationIdCursor(q.cursor());
+        byte[] lastId = decodeViolationIdCursor(q.cursor());
         try (PreparedStatement ps = c.prepareStatement(
                 "SELECT id, session_id, player_uuid, check_id, vl, occurred_at, verbose, verbose_format "
                         + "FROM " + config.tableNames().violations() + " "
@@ -690,7 +698,7 @@ public final class SqliteBackend implements Backend {
             ps.setBytes(1, UuidCodec.toBytes(q.sessionId()));
             ps.setLong(2, lastOccurred);
             ps.setLong(3, lastOccurred);
-            ps.setLong(4, lastId);
+            ps.setBytes(4, lastId);
             ps.setInt(5, q.pageSize() + 1);
             try (ResultSet rs = ps.executeQuery()) {
                 List<ViolationRecord> out = new ArrayList<>();
@@ -796,7 +804,7 @@ public final class SqliteBackend implements Backend {
 
     private static ViolationRecord mapViolation(ResultSet rs) throws SQLException {
         return new ViolationRecord(
-                rs.getLong("id"),
+                UuidCodec.fromBytes(rs.getBytes("id")),
                 UuidCodec.fromBytes(rs.getBytes("session_id")),
                 UuidCodec.fromBytes(rs.getBytes("player_uuid")),
                 rs.getInt("check_id"),
@@ -982,30 +990,24 @@ public final class SqliteBackend implements Backend {
         return out;
     }
 
-    private static Cursor encodeViolationCursor(long occurred, long id) {
-        return new Cursor("v:" + occurred + ":" + id);
+    private static Cursor encodeViolationCursor(long occurredAt, UUID id) {
+        return new Cursor("v:" + occurredAt + ":" + id);
     }
 
     private static long decodeViolationOccurredCursor(Cursor c, long defaultVal) {
         if (c == null) return defaultVal;
-        String[] parts = c.token().split(":");
-        if (parts.length < 3) return defaultVal;
-        try {
-            return Long.parseLong(parts[1]);
-        } catch (NumberFormatException e) {
-            return defaultVal;
-        }
+        String[] parts = c.token().split(":", 3);
+        if (parts.length < 3 || !"v".equals(parts[0])) return defaultVal;
+        try { return Long.parseLong(parts[1]); }
+        catch (NumberFormatException e) { return defaultVal; }
     }
 
-    private static long decodeViolationIdCursor(Cursor c) {
-        if (c == null) return Long.MIN_VALUE;
-        String[] parts = c.token().split(":");
-        if (parts.length < 3) return Long.MIN_VALUE;
-        try {
-            return Long.parseLong(parts[2]);
-        } catch (NumberFormatException e) {
-            return Long.MIN_VALUE;
-        }
+    private static byte[] decodeViolationIdCursor(Cursor c) {
+        if (c == null) return new byte[16];
+        String[] parts = c.token().split(":", 3);
+        if (parts.length < 3 || !"v".equals(parts[0])) return new byte[16];
+        try { return UuidCodec.toBytes(UUID.fromString(parts[2])); }
+        catch (IllegalArgumentException e) { return new byte[16]; }
     }
 
     @ApiStatus.Internal

--- a/grim-internal/src/main/java/ac/grim/grimac/internal/storage/backend/sqlite/SqliteBackend.java
+++ b/grim-internal/src/main/java/ac/grim/grimac/internal/storage/backend/sqlite/SqliteBackend.java
@@ -28,7 +28,6 @@ import ac.grim.grimac.internal.storage.backend.sqlite.writers.SessionUpserter;
 import ac.grim.grimac.internal.storage.backend.sqlite.writers.SettingsUpserter;
 import ac.grim.grimac.internal.storage.backend.sqlite.writers.UpserterFactory;
 import ac.grim.grimac.internal.storage.util.UuidCodec;
-import ac.grim.grimac.internal.storage.util.UuidV7;
 import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
 
@@ -421,7 +420,7 @@ public final class SqliteBackend implements Backend {
         @Override
         protected void bindOne(ViolationEvent v) throws SQLException {
             if (stmt == null) stmt = conn.prepareStatement(insertViolations);
-            UUID id = v.id() != null ? v.id() : UuidV7.next();
+            UUID id = v.id();
             stmt.setBytes(1, UuidCodec.toBytes(id));
             stmt.setBytes(2, UuidCodec.toBytes(v.sessionId()));
             stmt.setBytes(3, UuidCodec.toBytes(v.playerUuid()));

--- a/grim-internal/src/main/java/ac/grim/grimac/internal/storage/backend/sqlite/SqliteSchema.java
+++ b/grim-internal/src/main/java/ac/grim/grimac/internal/storage/backend/sqlite/SqliteSchema.java
@@ -2,6 +2,8 @@ package ac.grim.grimac.internal.storage.backend.sqlite;
 
 import ac.grim.grimac.api.storage.config.TableNames;
 import ac.grim.grimac.internal.storage.checks.LegacyKeyRenames;
+import ac.grim.grimac.internal.storage.util.UuidCodec;
+import ac.grim.grimac.internal.storage.util.UuidV7;
 import org.jetbrains.annotations.ApiStatus;
 
 import java.sql.Connection;
@@ -10,6 +12,7 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
 import java.util.Map;
+import java.util.UUID;
 
 /**
  * Creates tables + indexes + the meta singleton row on first touch. Idempotent:
@@ -30,7 +33,7 @@ import java.util.Map;
 @ApiStatus.Internal
 public final class SqliteSchema {
 
-    public static final int CURRENT_VERSION = 3;
+    public static final int CURRENT_VERSION = 4;
 
     private SqliteSchema() {}
 
@@ -71,6 +74,7 @@ public final class SqliteSchema {
         // gated on its target version.
         if (existing < 2) migrateV1ToV2(c, t);
         if (existing < 3) migrateV2ToV3(c, t);
+        if (existing < 4) migrateV3ToV4(c, t);
 
         if (existing < CURRENT_VERSION) {
             try (PreparedStatement ps = c.prepareStatement(
@@ -113,6 +117,88 @@ public final class SqliteSchema {
                 ps.addBatch();
             }
             ps.executeBatch();
+        }
+    }
+
+    /**
+     * v3 → v4: violation {@code id} type changes from {@code INTEGER PRIMARY
+     * KEY AUTOINCREMENT} to {@code BLOB PRIMARY KEY} carrying a 16-byte
+     * UUIDv7. SQLite can't change a column's type in-place, so this
+     * rebuilds the table: stream existing rows out, mint a UUIDv7 from each
+     * row's {@code occurred_at} (preserves chronological order), bulk-insert
+     * into a fresh table, then atomically swap.
+     *
+     * <p>Bogus {@code occurred_at} values (negative, missing) clamp to 0 in
+     * {@link UuidV7#fromTimestampMs} rather than aborting migration — the
+     * affected rows simply sort at the front of the new table.
+     */
+    private static void migrateV3ToV4(Connection c, TableNames t) throws SQLException {
+        String oldTable = t.violations();
+        String newTable = t.violations() + "_uuid_v7_tmp";
+
+        // SQLite has transactional DDL: wrap the whole rewrite so a crash
+        // anywhere before COMMIT rolls back to v3 shape with the canonical
+        // data untouched. The connection runs autocommit by default.
+        boolean priorAutoCommit = c.getAutoCommit();
+        c.setAutoCommit(false);
+        try {
+            try (Statement s = c.createStatement()) {
+                // Same transaction, so cleaning a stale tmp from an earlier
+                // aborted run is safe even if it were the only data copy
+                // (it isn't — the canonical lives in oldTable).
+                s.executeUpdate("DROP TABLE IF EXISTS " + newTable);
+                s.executeUpdate("CREATE TABLE " + newTable + " ("
+                        + "id BLOB PRIMARY KEY, "
+                        + "session_id BLOB NOT NULL, "
+                        + "player_uuid BLOB NOT NULL, "
+                        + "check_id INTEGER NOT NULL, "
+                        + "vl REAL NOT NULL, "
+                        + "occurred_at INTEGER NOT NULL, "
+                        + "verbose TEXT, "
+                        + "verbose_format INTEGER NOT NULL DEFAULT 0, "
+                        + "metadata TEXT"
+                        + ")");
+            }
+
+            try (PreparedStatement sel = c.prepareStatement(
+                    "SELECT session_id, player_uuid, check_id, vl, occurred_at, verbose, verbose_format, metadata "
+                            + "FROM " + oldTable);
+                 PreparedStatement ins = c.prepareStatement(
+                    "INSERT INTO " + newTable + "(id, session_id, player_uuid, check_id, vl, occurred_at, verbose, verbose_format, metadata) "
+                            + "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)");
+                 ResultSet rs = sel.executeQuery()) {
+                int batched = 0;
+                while (rs.next()) {
+                    long occurred = rs.getLong("occurred_at");
+                    UUID newId = UuidV7.fromTimestampMs(occurred);
+                    ins.setBytes(1, UuidCodec.toBytes(newId));
+                    ins.setBytes(2, rs.getBytes("session_id"));
+                    ins.setBytes(3, rs.getBytes("player_uuid"));
+                    ins.setInt(4, rs.getInt("check_id"));
+                    ins.setDouble(5, rs.getDouble("vl"));
+                    ins.setLong(6, occurred);
+                    ins.setString(7, rs.getString("verbose"));
+                    ins.setInt(8, rs.getInt("verbose_format"));
+                    ins.setString(9, rs.getString("metadata"));
+                    ins.addBatch();
+                    if (++batched % 1024 == 0) ins.executeBatch();
+                }
+                ins.executeBatch();
+            }
+
+            try (Statement s = c.createStatement()) {
+                s.executeUpdate("DROP TABLE " + oldTable);
+                s.executeUpdate("ALTER TABLE " + newTable + " RENAME TO " + oldTable);
+                s.executeUpdate("CREATE INDEX idx_" + oldTable + "_session_time ON " + oldTable + "(session_id, occurred_at)");
+                s.executeUpdate("CREATE INDEX idx_" + oldTable + "_player ON " + oldTable + "(player_uuid)");
+            }
+
+            c.commit();
+        } catch (SQLException e) {
+            try { c.rollback(); } catch (SQLException ignored) {}
+            throw e;
+        } finally {
+            c.setAutoCommit(priorAutoCommit);
         }
     }
 
@@ -169,8 +255,12 @@ public final class SqliteSchema {
                     + ")");
             s.executeUpdate("CREATE INDEX idx_" + t.sessions() + "_player_started ON " + t.sessions() + "(player_uuid, started_at DESC)");
 
+            // v4: id is a UUIDv7 stored as 16-byte BLOB. UUIDv7's timestamp
+            // prefix makes the primary-key B-tree append-friendly (new rows
+            // sort to the right) — equivalent locality to the v3
+            // AUTOINCREMENT, plus globally unique across JVMs sharing one DB.
             s.executeUpdate("CREATE TABLE " + t.violations() + " ("
-                    + "id INTEGER PRIMARY KEY AUTOINCREMENT, "
+                    + "id BLOB PRIMARY KEY, "
                     + "session_id BLOB NOT NULL, "
                     + "player_uuid BLOB NOT NULL, "
                     + "check_id INTEGER NOT NULL, "

--- a/grim-internal/src/main/java/ac/grim/grimac/internal/storage/backend/sqlite/SqliteSchema.java
+++ b/grim-internal/src/main/java/ac/grim/grimac/internal/storage/backend/sqlite/SqliteSchema.java
@@ -70,8 +70,7 @@ public final class SqliteSchema {
                     + "; refusing to downgrade. Roll Grim forward.");
         }
 
-        // Forward migrations — additive only; each step is idempotent and
-        // gated on its target version.
+        // Forward migrations; each step is idempotent and gated on its target version.
         if (existing < 2) migrateV1ToV2(c, t);
         if (existing < 3) migrateV2ToV3(c, t);
         if (existing < 4) migrateV3ToV4(c, t);
@@ -125,8 +124,9 @@ public final class SqliteSchema {
      * KEY AUTOINCREMENT} to {@code BLOB PRIMARY KEY} carrying a 16-byte
      * UUIDv7. SQLite can't change a column's type in-place, so this
      * rebuilds the table: stream existing rows out, mint a UUIDv7 from each
-     * row's {@code occurred_at} (preserves chronological order), bulk-insert
-     * into a fresh table, then atomically swap.
+     * row's {@code occurred_at} and old numeric id (preserves
+     * same-millisecond order), bulk-insert into a fresh table, then
+     * atomically swap.
      *
      * <p>Bogus {@code occurred_at} values (negative, missing) clamp to 0 in
      * {@link UuidV7#fromTimestampMs} rather than aborting migration — the
@@ -161,7 +161,7 @@ public final class SqliteSchema {
             }
 
             try (PreparedStatement sel = c.prepareStatement(
-                    "SELECT session_id, player_uuid, check_id, vl, occurred_at, verbose, verbose_format, metadata "
+                    "SELECT id, session_id, player_uuid, check_id, vl, occurred_at, verbose, verbose_format, metadata "
                             + "FROM " + oldTable);
                  PreparedStatement ins = c.prepareStatement(
                     "INSERT INTO " + newTable + "(id, session_id, player_uuid, check_id, vl, occurred_at, verbose, verbose_format, metadata) "
@@ -170,7 +170,7 @@ public final class SqliteSchema {
                 int batched = 0;
                 while (rs.next()) {
                     long occurred = rs.getLong("occurred_at");
-                    UUID newId = UuidV7.fromTimestampMs(occurred);
+                    UUID newId = UuidV7.fromTimestampMs(occurred, rs.getLong("id"));
                     ins.setBytes(1, UuidCodec.toBytes(newId));
                     ins.setBytes(2, rs.getBytes("session_id"));
                     ins.setBytes(3, rs.getBytes("player_uuid"));
@@ -189,7 +189,7 @@ public final class SqliteSchema {
             try (Statement s = c.createStatement()) {
                 s.executeUpdate("DROP TABLE " + oldTable);
                 s.executeUpdate("ALTER TABLE " + newTable + " RENAME TO " + oldTable);
-                s.executeUpdate("CREATE INDEX idx_" + oldTable + "_session_time ON " + oldTable + "(session_id, occurred_at)");
+                s.executeUpdate("CREATE INDEX idx_" + oldTable + "_session_time ON " + oldTable + "(session_id, occurred_at, id)");
                 s.executeUpdate("CREATE INDEX idx_" + oldTable + "_player ON " + oldTable + "(player_uuid)");
             }
 
@@ -270,7 +270,7 @@ public final class SqliteSchema {
                     + "verbose_format INTEGER NOT NULL DEFAULT 0, "
                     + "metadata TEXT"
                     + ")");
-            s.executeUpdate("CREATE INDEX idx_" + t.violations() + "_session_time ON " + t.violations() + "(session_id, occurred_at)");
+            s.executeUpdate("CREATE INDEX idx_" + t.violations() + "_session_time ON " + t.violations() + "(session_id, occurred_at, id)");
             s.executeUpdate("CREATE INDEX idx_" + t.violations() + "_player ON " + t.violations() + "(player_uuid)");
 
             s.executeUpdate("CREATE TABLE " + t.settings() + " ("

--- a/grim-internal/src/main/java/ac/grim/grimac/internal/storage/core/DataStoreImpl.java
+++ b/grim-internal/src/main/java/ac/grim/grimac/internal/storage/core/DataStoreImpl.java
@@ -8,11 +8,13 @@ import ac.grim.grimac.api.storage.backend.BackendException;
 import ac.grim.grimac.api.storage.category.Categories;
 import ac.grim.grimac.api.storage.category.Category;
 import ac.grim.grimac.api.storage.config.WritePathConfig;
+import ac.grim.grimac.api.storage.event.ViolationEvent;
 import ac.grim.grimac.api.storage.query.DeleteCriteria;
 import ac.grim.grimac.api.storage.query.Deletes;
 import ac.grim.grimac.api.storage.query.Page;
 import ac.grim.grimac.api.storage.query.Queries;
 import ac.grim.grimac.api.storage.query.Query;
+import ac.grim.grimac.internal.storage.util.UuidV7;
 import org.jetbrains.annotations.ApiStatus;
 
 import java.util.UUID;
@@ -76,7 +78,19 @@ public final class DataStoreImpl implements DataStore {
     @Override
     public <E> void submit(Category<E> cat, Consumer<E> configurer) {
         if (closed) return;
+        if (cat == Categories.VIOLATION) {
+            submitViolation(configurer);
+            return;
+        }
         rings.submit(cat, configurer);
+    }
+
+    @SuppressWarnings("unchecked")
+    private <E> void submitViolation(Consumer<E> configurer) {
+        rings.submit(Categories.VIOLATION, event -> {
+            ((Consumer<ViolationEvent>) configurer).accept(event);
+            if (event.id() == null) event.id(UuidV7.next());
+        });
     }
 
     @Override

--- a/grim-internal/src/main/java/ac/grim/grimac/internal/storage/core/RingRegistry.java
+++ b/grim-internal/src/main/java/ac/grim/grimac/internal/storage/core/RingRegistry.java
@@ -5,6 +5,11 @@ import ac.grim.grimac.api.storage.backend.BackendException;
 import ac.grim.grimac.api.storage.backend.StorageEventHandler;
 import ac.grim.grimac.api.storage.category.Category;
 import ac.grim.grimac.api.storage.config.WritePathConfig;
+import ac.grim.grimac.api.storage.event.BlobEvent;
+import ac.grim.grimac.api.storage.event.PlayerIdentityEvent;
+import ac.grim.grimac.api.storage.event.SessionEvent;
+import ac.grim.grimac.api.storage.event.SettingEvent;
+import ac.grim.grimac.api.storage.event.ViolationEvent;
 import com.lmax.disruptor.BatchEventProcessor;
 import com.lmax.disruptor.EventTranslatorOneArg;
 import com.lmax.disruptor.RingBuffer;
@@ -103,11 +108,11 @@ public final class RingRegistry {
      */
     @SuppressWarnings("unchecked")
     private static <E> E resetIfKnown(E event) {
-        if (event instanceof ac.grim.grimac.api.storage.event.ViolationEvent v) { v.reset(); return (E) v; }
-        if (event instanceof ac.grim.grimac.api.storage.event.SessionEvent s) { s.reset(); return (E) s; }
-        if (event instanceof ac.grim.grimac.api.storage.event.BlobEvent b) { b.reset(); return (E) b; }
-        if (event instanceof ac.grim.grimac.api.storage.event.PlayerIdentityEvent p) { p.reset(); return (E) p; }
-        if (event instanceof ac.grim.grimac.api.storage.event.SettingEvent s) { s.reset(); return (E) s; }
+        if (event instanceof ViolationEvent v) { v.reset(); return (E) v; }
+        if (event instanceof SessionEvent s) { s.reset(); return (E) s; }
+        if (event instanceof BlobEvent b) { b.reset(); return (E) b; }
+        if (event instanceof PlayerIdentityEvent p) { p.reset(); return (E) p; }
+        if (event instanceof SettingEvent s) { s.reset(); return (E) s; }
         return event;
     }
 

--- a/grim-internal/src/main/java/ac/grim/grimac/internal/storage/migrate/LegacyMigrator.java
+++ b/grim-internal/src/main/java/ac/grim/grimac/internal/storage/migrate/LegacyMigrator.java
@@ -136,7 +136,12 @@ public final class LegacyMigrator {
                         List<ViolationRecord> rows = new ArrayList<>(violations.size());
                         for (SessionReconstructor.ReconstructedViolation v : violations) {
                             rows.add(new ViolationRecord(
-                                    0,
+                                    // Synthesise a UUIDv7 from occurred_at so the
+                                    // migrated row's id is monotonic with its
+                                    // peers and lex-sortable as the v1 backend
+                                    // expects. The legacy long id isn't carried
+                                    // forward — only the chronology is.
+                                    ac.grim.grimac.internal.storage.util.UuidV7.fromTimestampMs(v.occurredEpochMs()),
                                     v.sessionId(),
                                     v.playerUuid(),
                                     v.checkId(),

--- a/grim-internal/src/main/java/ac/grim/grimac/internal/storage/migrate/LegacyMigrator.java
+++ b/grim-internal/src/main/java/ac/grim/grimac/internal/storage/migrate/LegacyMigrator.java
@@ -137,7 +137,7 @@ public final class LegacyMigrator {
                         List<ViolationRecord> rows = new ArrayList<>(violations.size());
                         for (SessionReconstructor.ReconstructedViolation v : violations) {
                             rows.add(new ViolationRecord(
-                                    UuidV7.fromTimestampMs(v.occurredEpochMs()),
+                                    UuidV7.fromTimestampMs(v.occurredEpochMs(), v.legacyId()),
                                     v.sessionId(),
                                     v.playerUuid(),
                                     v.checkId(),

--- a/grim-internal/src/main/java/ac/grim/grimac/internal/storage/migrate/LegacyMigrator.java
+++ b/grim-internal/src/main/java/ac/grim/grimac/internal/storage/migrate/LegacyMigrator.java
@@ -12,6 +12,7 @@ import ac.grim.grimac.api.storage.query.Page;
 import ac.grim.grimac.api.storage.query.Queries;
 import ac.grim.grimac.internal.storage.checks.CheckRegistry;
 import ac.grim.grimac.internal.storage.checks.StableKeyMapping;
+import ac.grim.grimac.internal.storage.util.UuidV7;
 import org.jetbrains.annotations.ApiStatus;
 
 import java.nio.charset.StandardCharsets;
@@ -136,12 +137,7 @@ public final class LegacyMigrator {
                         List<ViolationRecord> rows = new ArrayList<>(violations.size());
                         for (SessionReconstructor.ReconstructedViolation v : violations) {
                             rows.add(new ViolationRecord(
-                                    // Synthesise a UUIDv7 from occurred_at so the
-                                    // migrated row's id is monotonic with its
-                                    // peers and lex-sortable as the v1 backend
-                                    // expects. The legacy long id isn't carried
-                                    // forward — only the chronology is.
-                                    ac.grim.grimac.internal.storage.util.UuidV7.fromTimestampMs(v.occurredEpochMs()),
+                                    UuidV7.fromTimestampMs(v.occurredEpochMs()),
                                     v.sessionId(),
                                     v.playerUuid(),
                                     v.checkId(),

--- a/grim-internal/src/main/java/ac/grim/grimac/internal/storage/submit/ViolationSinkImpl.java
+++ b/grim-internal/src/main/java/ac/grim/grimac/internal/storage/submit/ViolationSinkImpl.java
@@ -29,19 +29,11 @@ public final class ViolationSinkImpl implements ViolationSink {
     @Override
     public @NotNull SubmitResult record(@NotNull Consumer<ViolationEvent> configurer) {
         if (closed) return SubmitResult.DROPPED_SHUTTING_DOWN;
-        // Wrap the caller's configurer so we always hand the backend an event
-        // with id() populated. Producer-side minting keeps the id round-trippable
-        // (cross-backend copy preserves it, the caller can read it back in
-        // future SubmitResult shapes) and matches the contract documented on
-        // ViolationEvent. A caller can still pre-set event.id() — we only
-        // mint when it's null after their configurer runs.
         store.submit(Categories.VIOLATION, event -> {
             configurer.accept(event);
             if (event.id() == null) event.id(UuidV7.next());
         });
-        // DataStoreImpl.submit is non-blocking; overflow is reflected in
-        // metrics().droppedOnOverflowTotal rather than returned here. We conservatively
-        // report QUEUED; a richer SubmitResult with queue-depth probing can follow.
+        // submit() is non-blocking; overflow is reported through metrics.
         return SubmitResult.QUEUED;
     }
 

--- a/grim-internal/src/main/java/ac/grim/grimac/internal/storage/submit/ViolationSinkImpl.java
+++ b/grim-internal/src/main/java/ac/grim/grimac/internal/storage/submit/ViolationSinkImpl.java
@@ -5,6 +5,7 @@ import ac.grim.grimac.api.storage.category.Categories;
 import ac.grim.grimac.api.storage.event.ViolationEvent;
 import ac.grim.grimac.api.storage.submit.SubmitResult;
 import ac.grim.grimac.api.storage.submit.ViolationSink;
+import ac.grim.grimac.internal.storage.util.UuidV7;
 import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
 
@@ -28,7 +29,16 @@ public final class ViolationSinkImpl implements ViolationSink {
     @Override
     public @NotNull SubmitResult record(@NotNull Consumer<ViolationEvent> configurer) {
         if (closed) return SubmitResult.DROPPED_SHUTTING_DOWN;
-        store.submit(Categories.VIOLATION, configurer);
+        // Wrap the caller's configurer so we always hand the backend an event
+        // with id() populated. Producer-side minting keeps the id round-trippable
+        // (cross-backend copy preserves it, the caller can read it back in
+        // future SubmitResult shapes) and matches the contract documented on
+        // ViolationEvent. A caller can still pre-set event.id() — we only
+        // mint when it's null after their configurer runs.
+        store.submit(Categories.VIOLATION, event -> {
+            configurer.accept(event);
+            if (event.id() == null) event.id(UuidV7.next());
+        });
         // DataStoreImpl.submit is non-blocking; overflow is reflected in
         // metrics().droppedOnOverflowTotal rather than returned here. We conservatively
         // report QUEUED; a richer SubmitResult with queue-depth probing can follow.

--- a/grim-internal/src/main/java/ac/grim/grimac/internal/storage/submit/ViolationSinkImpl.java
+++ b/grim-internal/src/main/java/ac/grim/grimac/internal/storage/submit/ViolationSinkImpl.java
@@ -5,7 +5,6 @@ import ac.grim.grimac.api.storage.category.Categories;
 import ac.grim.grimac.api.storage.event.ViolationEvent;
 import ac.grim.grimac.api.storage.submit.SubmitResult;
 import ac.grim.grimac.api.storage.submit.ViolationSink;
-import ac.grim.grimac.internal.storage.util.UuidV7;
 import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
 
@@ -29,10 +28,7 @@ public final class ViolationSinkImpl implements ViolationSink {
     @Override
     public @NotNull SubmitResult record(@NotNull Consumer<ViolationEvent> configurer) {
         if (closed) return SubmitResult.DROPPED_SHUTTING_DOWN;
-        store.submit(Categories.VIOLATION, event -> {
-            configurer.accept(event);
-            if (event.id() == null) event.id(UuidV7.next());
-        });
+        store.submit(Categories.VIOLATION, configurer);
         // submit() is non-blocking; overflow is reported through metrics.
         return SubmitResult.QUEUED;
     }

--- a/grim-internal/src/main/java/ac/grim/grimac/internal/storage/util/UuidV7.java
+++ b/grim-internal/src/main/java/ac/grim/grimac/internal/storage/util/UuidV7.java
@@ -8,14 +8,13 @@ import java.util.concurrent.atomic.AtomicLong;
 
 /**
  * RFC 9562 §5.7 UUIDv7 generator. Top 48 bits are unix-ms, the next 4 are
- * version 7, then 12 bits of random ("rand_a"), the variant nibble, and 62
- * bits of random ("rand_b"). The time prefix makes UUIDv7s k-sortable, so
- * unique-index B-trees stay write-friendly and cursor paging works with a
- * single {@code WHERE id > ?} predicate.
+ * version 7, then rand_a, the variant bits, and rand_b. The time prefix makes
+ * UUIDv7s k-sortable, so unique-index B-trees stay write-friendly and the id
+ * remains a stable tie-breaker for cursor paging.
  *
- * <p>Used by {@code ViolationSink} to mint ids producer-side and by the
- * per-backend schema migrations to synthesise stable replacement ids from
- * legacy {@code occurred_at} timestamps.
+ * <p>Used by the default {@code DataStore.submit} path to mint ids
+ * producer-side and by the per-backend schema migrations to synthesise stable
+ * replacement ids from legacy {@code occurred_at} timestamps.
  *
  * <p>{@link #next()} is strictly monotonic within a single JVM, even
  * across calls that land in the same wall-clock millisecond (RFC 9562
@@ -29,9 +28,9 @@ import java.util.concurrent.atomic.AtomicLong;
  * opposite to their event order, breaking the by-id monotonic-paging
  * contract the SQL backends rely on.
  *
- * <p>{@link #fromTimestampMs(long)} stays fully random — it's only used
- * during schema migration to synthesise replacement ids from legacy
- * rows, where the {@code occurred_at} field already encodes order.
+ * <p>{@link #fromTimestampMs(long)} keeps random suffix bits for tests and
+ * ad-hoc synthesis. Migration code uses {@link #fromTimestampMs(long, long)}
+ * so same-millisecond legacy rows keep their old numeric-id order.
  */
 @ApiStatus.Internal
 public final class UuidV7 {
@@ -42,6 +41,7 @@ public final class UuidV7 {
     private static final long VARIANT_BITS = 0x2L << 62;
     private static final long RAND_A_MASK = 0x0FFFL;
     private static final long RAND_B_MASK = 0x3FFFFFFFFFFFFFFFL;
+    private static final long DETERMINISTIC_LOW_MASK = (1L << 51) - 1L;
     private static final int SEQ_MAX = 0x3FFF;
     private static final int SEQ_BITS = 14;
     private static final long SEQ_MASK = (1L << SEQ_BITS) - 1L;
@@ -98,17 +98,36 @@ public final class UuidV7 {
     /**
      * Mint a UUIDv7 whose timestamp prefix encodes {@code tsMs} (clamped into
      * the 48-bit unsigned range). Used for migration: a legacy {@code long id}
-     * row's replacement UUID is synthesised from its {@code occurred_at} so
-     * the new ids preserve the original chronological ordering.
+     * row's replacement UUID can be synthesised from its {@code occurred_at}.
      *
      * <p>Bogus inputs (negative ts, ts past year ~10895) are clamped rather
      * than rejected so a single bad legacy row doesn't abort migration.
      */
     public static UUID fromTimestampMs(long tsMs) {
-        long ts = Math.max(0L, tsMs) & TS_MASK;
+        long ts = clampTimestamp(tsMs);
         ThreadLocalRandom r = ThreadLocalRandom.current();
         long msb = (ts << 16) | VERSION_BITS | (r.nextLong() & RAND_A_MASK);
         long lsb = VARIANT_BITS | (r.nextLong() & RAND_B_MASK);
         return new UUID(msb, lsb);
+    }
+
+    /**
+     * Mint a deterministic UUIDv7 for migration. {@code sequence} is encoded
+     * after the timestamp prefix, so for rows with the same {@code tsMs},
+     * UUID byte order follows the old monotonic numeric id order.
+     */
+    public static UUID fromTimestampMs(long tsMs, long sequence) {
+        long ts = clampTimestamp(tsMs);
+        long seq = sequence & Long.MAX_VALUE;
+        long randA = (seq >>> 51) & RAND_A_MASK;
+        long randB = seq & DETERMINISTIC_LOW_MASK;
+        long msb = (ts << 16) | VERSION_BITS | randA;
+        long lsb = VARIANT_BITS | randB;
+        return new UUID(msb, lsb);
+    }
+
+    private static long clampTimestamp(long tsMs) {
+        if (tsMs <= 0L) return 0L;
+        return Math.min(tsMs, TS_MASK);
     }
 }

--- a/grim-internal/src/main/java/ac/grim/grimac/internal/storage/util/UuidV7.java
+++ b/grim-internal/src/main/java/ac/grim/grimac/internal/storage/util/UuidV7.java
@@ -18,13 +18,15 @@ import java.util.concurrent.ThreadLocalRandom;
  *
  * <p>{@link #next()} is strictly monotonic within a single JVM, even
  * across calls that land in the same wall-clock millisecond (RFC 9562
- * §6.2 method 1, "monotonic random"). When consecutive calls hit the
- * same ms, a 14-bit per-ms sequence packed across rand_a and the top
- * of rand_b advances by one so each new id sorts strictly after the
- * previous. The Redis backend pages violations by ZSET score=occurred_at;
- * without this, two flags raised in the same ms could be returned in
- * UUID order opposite to their event order, breaking the by-id
- * monotonic-paging contract the SQL backends rely on.
+ * §6.2 method 1). For a given UUID timestamp, a 14-bit sequence packed
+ * across rand_a and the top of rand_b advances by one so each new id
+ * sorts strictly after the previous; the remaining 60 bits stay random.
+ * If the sequence is exhausted before the wall clock advances, the UUID
+ * timestamp advances logically by 1 ms rather than wrapping the counter.
+ * The Redis backend pages violations by ZSET score=occurred_at; without
+ * this, two flags raised in the same ms could be returned in UUID order
+ * opposite to their event order, breaking the by-id monotonic-paging
+ * contract the SQL backends rely on.
  *
  * <p>{@link #fromTimestampMs(long)} stays fully random — it's only used
  * during schema migration to synthesise replacement ids from legacy
@@ -39,11 +41,11 @@ public final class UuidV7 {
     private static final long VARIANT_BITS = 0x2L << 62;
     private static final long RAND_A_MASK = 0x0FFFL;
     private static final long RAND_B_MASK = 0x3FFFFFFFFFFFFFFFL;
+    private static final int SEQ_MAX = 0x3FFF;
 
     // Same-ms monotonicity state. seq is a 14-bit counter — 12 bits in
     // rand_a + top 2 bits of rand_b — so byte order strictly increases
-    // for each new mint within the same ms (up to 16384 mints/ms before
-    // the counter would wrap; far above realistic load).
+    // for each new mint within the same UUID timestamp.
     private static long lastMs = -1L;
     private static int seq;
 
@@ -52,26 +54,29 @@ public final class UuidV7 {
     /**
      * Mint a UUIDv7 from the current wall clock. Strictly monotonic
      * within a single JVM. If the system clock steps backwards (NTP),
-     * the previous ms is held until wall-clock catches up rather than
-     * minting non-monotonic ids.
+     * the previous UUID timestamp is held; if more than 16384 ids are
+     * minted for one timestamp, the UUID timestamp advances logically
+     * rather than wrapping and minting non-monotonic ids. The violation
+     * record's {@code occurred_at} remains the authoritative event time.
      */
     public static synchronized UUID next() {
-        long now = System.currentTimeMillis();
-        long ts;
+        long now = Math.min(System.currentTimeMillis(), TS_MASK);
         if (now > lastMs) {
             lastMs = now;
-            // Seed each ms with a fresh random starting point so two JVMs
-            // minting in the same ms still produce non-overlapping id ranges.
-            seq = ThreadLocalRandom.current().nextInt() & 0x3FFF;
-            ts = now;
+            seq = 0;
+        } else if (seq < SEQ_MAX) {
+            seq++;
         } else {
-            seq = (seq + 1) & 0x3FFF;
-            ts = lastMs;
+            if (lastMs == TS_MASK) {
+                throw new IllegalStateException("UUIDv7 timestamp exhausted");
+            }
+            lastMs++;
+            seq = 0;
         }
         long randA = ((long) (seq >>> 2)) & RAND_A_MASK;                                // top 12 bits of seq
         long randBHigh = ((long) (seq & 0x3)) << 60;                                    // bottom 2 bits in rand_b MSBs
         long randBLow = ThreadLocalRandom.current().nextLong() & 0x0FFFFFFFFFFFFFFFL;   // remaining 60 random bits
-        long msb = (ts << 16) | VERSION_BITS | randA;
+        long msb = (lastMs << 16) | VERSION_BITS | randA;
         long lsb = VARIANT_BITS | randBHigh | randBLow;
         return new UUID(msb, lsb);
     }

--- a/grim-internal/src/main/java/ac/grim/grimac/internal/storage/util/UuidV7.java
+++ b/grim-internal/src/main/java/ac/grim/grimac/internal/storage/util/UuidV7.java
@@ -4,6 +4,7 @@ import org.jetbrains.annotations.ApiStatus;
 
 import java.util.UUID;
 import java.util.concurrent.ThreadLocalRandom;
+import java.util.concurrent.atomic.AtomicLong;
 
 /**
  * RFC 9562 §5.7 UUIDv7 generator. Top 48 bits are unix-ms, the next 4 are
@@ -42,12 +43,16 @@ public final class UuidV7 {
     private static final long RAND_A_MASK = 0x0FFFL;
     private static final long RAND_B_MASK = 0x3FFFFFFFFFFFFFFFL;
     private static final int SEQ_MAX = 0x3FFF;
+    private static final int SEQ_BITS = 14;
+    private static final long SEQ_MASK = (1L << SEQ_BITS) - 1L;
 
-    // Same-ms monotonicity state. seq is a 14-bit counter — 12 bits in
-    // rand_a + top 2 bits of rand_b — so byte order strictly increases
-    // for each new mint within the same UUID timestamp.
-    private static long lastMs = -1L;
-    private static int seq;
+    // Same-ms monotonicity state packed into a single AtomicLong so concurrent
+    // next() calls advance the counter via lock-free CAS instead of fighting a
+    // monitor: high 48 bits = last UUID timestamp, low 14 bits = sequence.
+    // Initial state: lastMs = -1 so the first call always falls into the
+    // "now > lastMs" branch. Encodes as 0xFFFF_FFFF_FFFF_C000 once shifted, but
+    // we only read it via the unpack accessors so the sign is preserved.
+    private static final AtomicLong STATE = new AtomicLong(-1L << SEQ_BITS);
 
     private UuidV7() {}
 
@@ -59,24 +64,33 @@ public final class UuidV7 {
      * rather than wrapping and minting non-monotonic ids. The violation
      * record's {@code occurred_at} remains the authoritative event time.
      */
-    public static synchronized UUID next() {
+    public static UUID next() {
         long now = Math.min(System.currentTimeMillis(), TS_MASK);
-        if (now > lastMs) {
-            lastMs = now;
-            seq = 0;
-        } else if (seq < SEQ_MAX) {
-            seq++;
-        } else {
-            if (lastMs == TS_MASK) {
-                throw new IllegalStateException("UUIDv7 timestamp exhausted");
+        long ts;
+        int seq;
+        while (true) {
+            long packed = STATE.get();
+            long lastMs = packed >> SEQ_BITS;
+            int lastSeq = (int) (packed & SEQ_MASK);
+            if (now > lastMs) {
+                ts = now;
+                seq = 0;
+            } else if (lastSeq < SEQ_MAX) {
+                ts = lastMs;
+                seq = lastSeq + 1;
+            } else {
+                if (lastMs == TS_MASK) {
+                    throw new IllegalStateException("UUIDv7 timestamp exhausted");
+                }
+                ts = lastMs + 1;
+                seq = 0;
             }
-            lastMs++;
-            seq = 0;
+            if (STATE.compareAndSet(packed, (ts << SEQ_BITS) | seq)) break;
         }
         long randA = ((long) (seq >>> 2)) & RAND_A_MASK;                                // top 12 bits of seq
         long randBHigh = ((long) (seq & 0x3)) << 60;                                    // bottom 2 bits in rand_b MSBs
         long randBLow = ThreadLocalRandom.current().nextLong() & 0x0FFFFFFFFFFFFFFFL;   // remaining 60 random bits
-        long msb = (lastMs << 16) | VERSION_BITS | randA;
+        long msb = (ts << 16) | VERSION_BITS | randA;
         long lsb = VARIANT_BITS | randBHigh | randBLow;
         return new UUID(msb, lsb);
     }

--- a/grim-internal/src/main/java/ac/grim/grimac/internal/storage/util/UuidV7.java
+++ b/grim-internal/src/main/java/ac/grim/grimac/internal/storage/util/UuidV7.java
@@ -1,0 +1,95 @@
+package ac.grim.grimac.internal.storage.util;
+
+import org.jetbrains.annotations.ApiStatus;
+
+import java.util.UUID;
+import java.util.concurrent.ThreadLocalRandom;
+
+/**
+ * RFC 9562 §5.7 UUIDv7 generator. Top 48 bits are unix-ms, the next 4 are
+ * version 7, then 12 bits of random ("rand_a"), the variant nibble, and 62
+ * bits of random ("rand_b"). The time prefix makes UUIDv7s k-sortable, so
+ * unique-index B-trees stay write-friendly and cursor paging works with a
+ * single {@code WHERE id > ?} predicate.
+ *
+ * <p>Used by {@code ViolationSink} to mint ids producer-side and by the
+ * per-backend schema migrations to synthesise stable replacement ids from
+ * legacy {@code occurred_at} timestamps.
+ *
+ * <p>{@link #next()} is strictly monotonic within a single JVM, even
+ * across calls that land in the same wall-clock millisecond (RFC 9562
+ * §6.2 method 1, "monotonic random"). When consecutive calls hit the
+ * same ms, a 14-bit per-ms sequence packed across rand_a and the top
+ * of rand_b advances by one so each new id sorts strictly after the
+ * previous. The Redis backend pages violations by ZSET score=occurred_at;
+ * without this, two flags raised in the same ms could be returned in
+ * UUID order opposite to their event order, breaking the by-id
+ * monotonic-paging contract the SQL backends rely on.
+ *
+ * <p>{@link #fromTimestampMs(long)} stays fully random — it's only used
+ * during schema migration to synthesise replacement ids from legacy
+ * rows, where the {@code occurred_at} field already encodes order.
+ */
+@ApiStatus.Internal
+public final class UuidV7 {
+
+    /** Largest representable 48-bit unsigned millisecond timestamp. */
+    private static final long TS_MASK = (1L << 48) - 1L;
+    private static final long VERSION_BITS = 0x7L << 12;
+    private static final long VARIANT_BITS = 0x2L << 62;
+    private static final long RAND_A_MASK = 0x0FFFL;
+    private static final long RAND_B_MASK = 0x3FFFFFFFFFFFFFFFL;
+
+    // Same-ms monotonicity state. seq is a 14-bit counter — 12 bits in
+    // rand_a + top 2 bits of rand_b — so byte order strictly increases
+    // for each new mint within the same ms (up to 16384 mints/ms before
+    // the counter would wrap; far above realistic load).
+    private static long lastMs = -1L;
+    private static int seq;
+
+    private UuidV7() {}
+
+    /**
+     * Mint a UUIDv7 from the current wall clock. Strictly monotonic
+     * within a single JVM. If the system clock steps backwards (NTP),
+     * the previous ms is held until wall-clock catches up rather than
+     * minting non-monotonic ids.
+     */
+    public static synchronized UUID next() {
+        long now = System.currentTimeMillis();
+        long ts;
+        if (now > lastMs) {
+            lastMs = now;
+            // Seed each ms with a fresh random starting point so two JVMs
+            // minting in the same ms still produce non-overlapping id ranges.
+            seq = ThreadLocalRandom.current().nextInt() & 0x3FFF;
+            ts = now;
+        } else {
+            seq = (seq + 1) & 0x3FFF;
+            ts = lastMs;
+        }
+        long randA = ((long) (seq >>> 2)) & RAND_A_MASK;                                // top 12 bits of seq
+        long randBHigh = ((long) (seq & 0x3)) << 60;                                    // bottom 2 bits in rand_b MSBs
+        long randBLow = ThreadLocalRandom.current().nextLong() & 0x0FFFFFFFFFFFFFFFL;   // remaining 60 random bits
+        long msb = (ts << 16) | VERSION_BITS | randA;
+        long lsb = VARIANT_BITS | randBHigh | randBLow;
+        return new UUID(msb, lsb);
+    }
+
+    /**
+     * Mint a UUIDv7 whose timestamp prefix encodes {@code tsMs} (clamped into
+     * the 48-bit unsigned range). Used for migration: a legacy {@code long id}
+     * row's replacement UUID is synthesised from its {@code occurred_at} so
+     * the new ids preserve the original chronological ordering.
+     *
+     * <p>Bogus inputs (negative ts, ts past year ~10895) are clamped rather
+     * than rejected so a single bad legacy row doesn't abort migration.
+     */
+    public static UUID fromTimestampMs(long tsMs) {
+        long ts = Math.max(0L, tsMs) & TS_MASK;
+        ThreadLocalRandom r = ThreadLocalRandom.current();
+        long msb = (ts << 16) | VERSION_BITS | (r.nextLong() & RAND_A_MASK);
+        long lsb = VARIANT_BITS | (r.nextLong() & RAND_B_MASK);
+        return new UUID(msb, lsb);
+    }
+}

--- a/grim-internal/src/test/java/ac/grim/grimac/internal/storage/backend/BackendIntegrationTest.java
+++ b/grim-internal/src/test/java/ac/grim/grimac/internal/storage/backend/BackendIntegrationTest.java
@@ -138,8 +138,8 @@ class BackendIntegrationTest {
             StorageEventHandler<ViolationEvent> vh = b.eventHandlerFor(Categories.VIOLATION);
             for (int i = 0; i < 5; i++) {
                 ViolationEvent v = new ViolationEvent();
-                v.id(UuidV7.fromTimestampMs(now + i)).sessionId(session).playerUuid(player).checkId(42 + i).vl(1.0 + i)
-                        .occurredEpochMs(now + i).verbose("v" + i).verboseFormat(VerboseFormat.TEXT);
+                v.id(UuidV7.fromTimestampMs(now, i + 1L)).sessionId(session).playerUuid(player).checkId(42 + i).vl(1.0 + i)
+                        .occurredEpochMs(now).verbose("v" + i).verboseFormat(VerboseFormat.TEXT);
                 vh.onEvent(v, i, i == 4);
             }
 
@@ -187,7 +187,7 @@ class BackendIntegrationTest {
             Page<ViolationRecord> second = b.read(Categories.VIOLATION,
                     new Queries.ListViolationsInSession(session, 2, first.nextCursor()));
             assertEquals(2, second.items().size(), label + ": page 2");
-            // UUIDv7 compareTo order matches these test timestamps.
+            // Same-ms rows page by deterministic UUIDv7 sequence.
             assertTrue(first.items().get(0).id().compareTo(second.items().get(0).id()) < 0,
                     label + ": monotonic id");
 

--- a/grim-internal/src/test/java/ac/grim/grimac/internal/storage/backend/BackendIntegrationTest.java
+++ b/grim-internal/src/test/java/ac/grim/grimac/internal/storage/backend/BackendIntegrationTest.java
@@ -28,6 +28,7 @@ import ac.grim.grimac.internal.storage.backend.postgres.PostgresBackend;
 import ac.grim.grimac.internal.storage.backend.postgres.PostgresBackendConfig;
 import ac.grim.grimac.internal.storage.backend.redis.RedisBackend;
 import ac.grim.grimac.internal.storage.backend.redis.RedisBackendConfig;
+import ac.grim.grimac.internal.storage.util.UuidV7;
 import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -137,7 +138,7 @@ class BackendIntegrationTest {
             StorageEventHandler<ViolationEvent> vh = b.eventHandlerFor(Categories.VIOLATION);
             for (int i = 0; i < 5; i++) {
                 ViolationEvent v = new ViolationEvent();
-                v.sessionId(session).playerUuid(player).checkId(42 + i).vl(1.0 + i)
+                v.id(UuidV7.fromTimestampMs(now + i)).sessionId(session).playerUuid(player).checkId(42 + i).vl(1.0 + i)
                         .occurredEpochMs(now + i).verbose("v" + i).verboseFormat(VerboseFormat.TEXT);
                 vh.onEvent(v, i, i == 4);
             }
@@ -186,11 +187,7 @@ class BackendIntegrationTest {
             Page<ViolationRecord> second = b.read(Categories.VIOLATION,
                     new Queries.ListViolationsInSession(session, 2, first.nextCursor()));
             assertEquals(2, second.items().size(), label + ": page 2");
-            // UUIDv7 ids are k-sortable by big-endian byte order — equivalent
-            // to chronological order for our purposes. UUID.compareTo() is
-            // signed-long-pair comparison which differs from byte order for
-            // top-bit values, but UUIDv7 timestamps stay well below the sign
-            // bit (year 10895), so compareTo gives the right ordering here.
+            // UUIDv7 compareTo order matches these test timestamps.
             assertTrue(first.items().get(0).id().compareTo(second.items().get(0).id()) < 0,
                     label + ": monotonic id");
 

--- a/grim-internal/src/test/java/ac/grim/grimac/internal/storage/backend/BackendIntegrationTest.java
+++ b/grim-internal/src/test/java/ac/grim/grimac/internal/storage/backend/BackendIntegrationTest.java
@@ -186,7 +186,13 @@ class BackendIntegrationTest {
             Page<ViolationRecord> second = b.read(Categories.VIOLATION,
                     new Queries.ListViolationsInSession(session, 2, first.nextCursor()));
             assertEquals(2, second.items().size(), label + ": page 2");
-            assertTrue(first.items().get(0).id() < second.items().get(0).id(), label + ": monotonic id");
+            // UUIDv7 ids are k-sortable by big-endian byte order — equivalent
+            // to chronological order for our purposes. UUID.compareTo() is
+            // signed-long-pair comparison which differs from byte order for
+            // top-bit values, but UUIDv7 timestamps stay well below the sign
+            // bit (year 10895), so compareTo gives the right ordering here.
+            assertTrue(first.items().get(0).id().compareTo(second.items().get(0).id()) < 0,
+                    label + ": monotonic id");
 
             // --- delete ---
             b.delete(Categories.SESSION, new Deletes.ByPlayer(player));

--- a/grim-internal/src/test/java/ac/grim/grimac/internal/storage/backend/mysql/MysqlBackendDialectTest.java
+++ b/grim-internal/src/test/java/ac/grim/grimac/internal/storage/backend/mysql/MysqlBackendDialectTest.java
@@ -119,8 +119,8 @@ class MysqlBackendDialectTest {
             StorageEventHandler<ViolationEvent> vh = b.eventHandlerFor(Categories.VIOLATION);
             for (int i = 0; i < 5; i++) {
                 ViolationEvent v = new ViolationEvent();
-                v.id(UuidV7.fromTimestampMs(t0 + i)).sessionId(session).playerUuid(player).checkId(42 + i).vl(1.0 + i)
-                        .occurredEpochMs(t0 + i).verbose("v" + i).verboseFormat(VerboseFormat.TEXT);
+                v.id(UuidV7.fromTimestampMs(t0, i + 1L)).sessionId(session).playerUuid(player).checkId(42 + i).vl(1.0 + i)
+                        .occurredEpochMs(t0).verbose("v" + i).verboseFormat(VerboseFormat.TEXT);
                 vh.onEvent(v, i, i == 4);
             }
 
@@ -188,15 +188,15 @@ class MysqlBackendDialectTest {
      * {@code current_name_lower} column, schema_version=7), then boots
      * MysqlBackend and verifies the v7→v8 migration ran: the gen col exists
      * and is auto-populated, the new plain index is in place, the old
-     * functional index is gone, schema_version is 8, and read queries
-     * still work end-to-end.
+     * functional index is gone, schema_version reaches current, and read
+     * queries still work end-to-end.
      * <p>
      * MariaDB-only: skipped on MariaDB because no v7 MariaDB schema ever
      * existed (the dialect failed to initialise pre-this-PR; new MariaDB
      * deployments are born at v8 directly via the unified baseline).
      */
     @org.junit.jupiter.api.Test
-    @DisplayName("MySQL v7→v8 migration — gen col + index swap on existing database")
+    @DisplayName("MySQL v7→current migration — gen col/index swap and UUID violation ids")
     void v7ToV8Migration(@TempDir Path tempDir) throws Exception {
         Flavor flavor = Flavor.MYSQL;
         assumeTrue(reachable(flavor), "Skipping; mysql fixture not reachable");

--- a/grim-internal/src/test/java/ac/grim/grimac/internal/storage/backend/mysql/MysqlBackendDialectTest.java
+++ b/grim-internal/src/test/java/ac/grim/grimac/internal/storage/backend/mysql/MysqlBackendDialectTest.java
@@ -18,6 +18,7 @@ import ac.grim.grimac.api.storage.model.VerboseFormat;
 import ac.grim.grimac.api.storage.model.ViolationRecord;
 import ac.grim.grimac.api.storage.query.Page;
 import ac.grim.grimac.api.storage.query.Queries;
+import ac.grim.grimac.internal.storage.util.UuidV7;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.io.TempDir;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -118,7 +119,7 @@ class MysqlBackendDialectTest {
             StorageEventHandler<ViolationEvent> vh = b.eventHandlerFor(Categories.VIOLATION);
             for (int i = 0; i < 5; i++) {
                 ViolationEvent v = new ViolationEvent();
-                v.sessionId(session).playerUuid(player).checkId(42 + i).vl(1.0 + i)
+                v.id(UuidV7.fromTimestampMs(t0 + i)).sessionId(session).playerUuid(player).checkId(42 + i).vl(1.0 + i)
                         .occurredEpochMs(t0 + i).verbose("v" + i).verboseFormat(VerboseFormat.TEXT);
                 vh.onEvent(v, i, i == 4);
             }

--- a/grim-internal/src/test/java/ac/grim/grimac/internal/storage/backend/mysql/MysqlBackendDialectTest.java
+++ b/grim-internal/src/test/java/ac/grim/grimac/internal/storage/backend/mysql/MysqlBackendDialectTest.java
@@ -270,7 +270,21 @@ class MysqlBackendDialectTest {
                  Statement s = c.createStatement()) {
                 try (ResultSet rs = s.executeQuery("SELECT schema_version FROM grim.grim_meta WHERE id = 0")) {
                     org.junit.jupiter.api.Assertions.assertTrue(rs.next());
-                    assertEquals(8, rs.getInt(1), "schema_version bumped to 8");
+                    // v7 seed → migration walks all forward steps (v7→v8 player
+                    // gen col swap, then v8→v9 violation id long→UUIDv7).
+                    assertEquals(MysqlSchema.CURRENT_VERSION, rs.getInt(1),
+                            "schema_version walks forward to current");
+                }
+                // Verify the v8→v9 step also ran: violations.id is now BINARY(16).
+                try (ResultSet rs = s.executeQuery(
+                        "SELECT DATA_TYPE, COLUMN_TYPE FROM information_schema.COLUMNS "
+                                + "WHERE TABLE_SCHEMA = 'grim' AND TABLE_NAME = 'grim_violations' "
+                                + "AND COLUMN_NAME = 'id'")) {
+                    org.junit.jupiter.api.Assertions.assertTrue(rs.next());
+                    assertEquals("binary", rs.getString(1).toLowerCase(java.util.Locale.ROOT),
+                            "violations.id is BINARY after v8→v9");
+                    assertEquals("binary(16)", rs.getString(2).toLowerCase(java.util.Locale.ROOT),
+                            "violations.id is BINARY(16) after v8→v9");
                 }
                 try (ResultSet rs = s.executeQuery(
                         "SELECT current_name_lower FROM grim.grim_players WHERE uuid = UNHEX('0000000000000000000000000000007F')")) {

--- a/grim-internal/src/test/java/ac/grim/grimac/internal/storage/backend/sqlite/SqliteBackendDialectTest.java
+++ b/grim-internal/src/test/java/ac/grim/grimac/internal/storage/backend/sqlite/SqliteBackendDialectTest.java
@@ -85,8 +85,8 @@ class SqliteBackendDialectTest {
             StorageEventHandler<ViolationEvent> vh = b.eventHandlerFor(Categories.VIOLATION);
             for (int i = 0; i < 5; i++) {
                 ViolationEvent v = new ViolationEvent();
-                v.id(UuidV7.fromTimestampMs(t0 + i)).sessionId(session).playerUuid(player).checkId(42 + i).vl(1.0 + i)
-                        .occurredEpochMs(t0 + i).verbose("v" + i).verboseFormat(VerboseFormat.TEXT);
+                v.id(UuidV7.fromTimestampMs(t0, i + 1L)).sessionId(session).playerUuid(player).checkId(42 + i).vl(1.0 + i)
+                        .occurredEpochMs(t0).verbose("v" + i).verboseFormat(VerboseFormat.TEXT);
                 vh.onEvent(v, i, i == 4);
             }
 

--- a/grim-internal/src/test/java/ac/grim/grimac/internal/storage/backend/sqlite/SqliteBackendDialectTest.java
+++ b/grim-internal/src/test/java/ac/grim/grimac/internal/storage/backend/sqlite/SqliteBackendDialectTest.java
@@ -19,6 +19,7 @@ import ac.grim.grimac.api.storage.model.ViolationRecord;
 import ac.grim.grimac.api.storage.query.Page;
 import ac.grim.grimac.api.storage.query.Queries;
 import ac.grim.grimac.internal.storage.backend.sqlite.writers.UpserterFactory;
+import ac.grim.grimac.internal.storage.util.UuidV7;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.io.TempDir;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -84,7 +85,7 @@ class SqliteBackendDialectTest {
             StorageEventHandler<ViolationEvent> vh = b.eventHandlerFor(Categories.VIOLATION);
             for (int i = 0; i < 5; i++) {
                 ViolationEvent v = new ViolationEvent();
-                v.sessionId(session).playerUuid(player).checkId(42 + i).vl(1.0 + i)
+                v.id(UuidV7.fromTimestampMs(t0 + i)).sessionId(session).playerUuid(player).checkId(42 + i).vl(1.0 + i)
                         .occurredEpochMs(t0 + i).verbose("v" + i).verboseFormat(VerboseFormat.TEXT);
                 vh.onEvent(v, i, i == 4);
             }

--- a/grim-internal/src/test/java/ac/grim/grimac/internal/storage/core/DataStoreImplTest.java
+++ b/grim-internal/src/test/java/ac/grim/grimac/internal/storage/core/DataStoreImplTest.java
@@ -1,0 +1,90 @@
+package ac.grim.grimac.internal.storage.core;
+
+import ac.grim.grimac.api.storage.backend.ApiVersion;
+import ac.grim.grimac.api.storage.backend.Backend;
+import ac.grim.grimac.api.storage.backend.BackendContext;
+import ac.grim.grimac.api.storage.backend.BackendException;
+import ac.grim.grimac.api.storage.backend.StorageEventHandler;
+import ac.grim.grimac.api.storage.category.Capability;
+import ac.grim.grimac.api.storage.category.Categories;
+import ac.grim.grimac.api.storage.category.Category;
+import ac.grim.grimac.api.storage.config.WaitStrategyType;
+import ac.grim.grimac.api.storage.config.WritePathConfig;
+import ac.grim.grimac.api.storage.event.ViolationEvent;
+import ac.grim.grimac.api.storage.query.DeleteCriteria;
+import ac.grim.grimac.api.storage.query.Page;
+import ac.grim.grimac.api.storage.query.Query;
+import org.junit.jupiter.api.Test;
+
+import java.util.EnumSet;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.logging.Logger;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class DataStoreImplTest {
+
+    @Test
+    void directViolationSubmitMintsIdBeforeBackendReceivesEvent() throws Exception {
+        CapturingViolationBackend backend = new CapturingViolationBackend();
+        DataStoreImpl store = new DataStoreImpl(
+                new CategoryRouter(Map.of(Categories.VIOLATION, backend)),
+                new WritePathConfig(8, 1, 1L, 10_000L, 1_000L, WaitStrategyType.BLOCKING),
+                Logger.getLogger("DataStoreImplTest"));
+        store.start();
+
+        try {
+            store.submit(Categories.VIOLATION, event -> event
+                    .sessionId(UUID.randomUUID())
+                    .playerUuid(UUID.randomUUID())
+                    .checkId(7)
+                    .vl(1.0)
+                    .occurredEpochMs(1_700_000_000_000L));
+
+            assertTrue(backend.await(), "backend received violation event");
+            assertNotNull(backend.id.get(), "DataStore submit path fills violation id");
+        } finally {
+            store.flushAndClose(1_000L);
+        }
+    }
+
+    private static final class CapturingViolationBackend implements Backend {
+        private final CountDownLatch seen = new CountDownLatch(1);
+        private final AtomicReference<UUID> id = new AtomicReference<>();
+
+        boolean await() throws InterruptedException {
+            return seen.await(2, TimeUnit.SECONDS);
+        }
+
+        @Override public String id() { return "capturing"; }
+        @Override public ApiVersion getApiVersion() { return ApiVersion.CURRENT; }
+        @Override
+        public EnumSet<Capability> capabilities() {
+            return EnumSet.of(Capability.INDEXED_KV, Capability.TIMESERIES_APPEND, Capability.HISTORY);
+        }
+        @Override public Set<Category<?>> supportedCategories() { return Set.of(Categories.VIOLATION); }
+        @Override public void init(BackendContext ctx) {}
+        @Override public void flush() {}
+        @Override public void close() {}
+
+        @Override
+        @SuppressWarnings("unchecked")
+        public <E> StorageEventHandler<E> eventHandlerFor(Category<E> cat) throws BackendException {
+            if (cat != Categories.VIOLATION) throw new BackendException("unsupported category: " + cat.id());
+            return (StorageEventHandler<E>) (StorageEventHandler<ViolationEvent>) (event, sequence, endOfBatch) -> {
+                id.set(event.id());
+                seen.countDown();
+            };
+        }
+
+        @Override public <R> Page<R> read(Category<?> cat, Query<R> query) { return Page.empty(); }
+        @Override public <E> void delete(Category<E> cat, DeleteCriteria criteria) {}
+        @Override public long countViolationsInSession(UUID sessionId) { return 0L; }
+    }
+}

--- a/grim-internal/src/test/java/ac/grim/grimac/internal/storage/util/UuidV7Test.java
+++ b/grim-internal/src/test/java/ac/grim/grimac/internal/storage/util/UuidV7Test.java
@@ -1,0 +1,39 @@
+package ac.grim.grimac.internal.storage.util;
+
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Field;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class UuidV7Test {
+
+    @Test
+    void sequenceOverflowAdvancesLogicalTimestamp() throws Exception {
+        Field lastMsField = UuidV7.class.getDeclaredField("lastMs");
+        Field seqField = UuidV7.class.getDeclaredField("seq");
+        lastMsField.setAccessible(true);
+        seqField.setAccessible(true);
+
+        try {
+            long fixedMs = System.currentTimeMillis() + 10_000L;
+            lastMsField.setLong(null, fixedMs);
+            seqField.setInt(null, 0x3FFE);
+
+            UUID lastInMs = UuidV7.next();
+            UUID logicalNextMs = UuidV7.next();
+
+            assertTrue(lastInMs.compareTo(logicalNextMs) < 0);
+            assertEquals(timestampMs(lastInMs) + 1, timestampMs(logicalNextMs));
+        } finally {
+            lastMsField.setLong(null, -1L);
+            seqField.setInt(null, 0);
+        }
+    }
+
+    private static long timestampMs(UUID uuid) {
+        return (uuid.getMostSignificantBits() >>> 16) & ((1L << 48) - 1L);
+    }
+}

--- a/grim-internal/src/test/java/ac/grim/grimac/internal/storage/util/UuidV7Test.java
+++ b/grim-internal/src/test/java/ac/grim/grimac/internal/storage/util/UuidV7Test.java
@@ -12,6 +12,26 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 class UuidV7Test {
 
     @Test
+    void deterministicMigrationIdsPreserveSameTimestampSequenceOrder() {
+        long ts = 1_700_000_000_000L;
+
+        UUID first = UuidV7.fromTimestampMs(ts, 41L);
+        UUID second = UuidV7.fromTimestampMs(ts, 42L);
+
+        assertTrue(first.compareTo(second) < 0);
+        assertEquals(first, UuidV7.fromTimestampMs(ts, 41L));
+        assertEquals(ts, timestampMs(first));
+    }
+
+    @Test
+    void timestampClampDoesNotWrapFutureValues() {
+        long max = (1L << 48) - 1L;
+
+        assertEquals(0L, timestampMs(UuidV7.fromTimestampMs(-1L)));
+        assertEquals(max, timestampMs(UuidV7.fromTimestampMs(max + 1L)));
+    }
+
+    @Test
     void sequenceOverflowAdvancesLogicalTimestamp() throws Exception {
         // Force the internal state to (fixedMs, seq=0x3FFE) so the next two
         // calls hit (a) the last slot of the current ms and (b) the overflow

--- a/grim-internal/src/test/java/ac/grim/grimac/internal/storage/util/UuidV7Test.java
+++ b/grim-internal/src/test/java/ac/grim/grimac/internal/storage/util/UuidV7Test.java
@@ -4,6 +4,7 @@ import org.junit.jupiter.api.Test;
 
 import java.lang.reflect.Field;
 import java.util.UUID;
+import java.util.concurrent.atomic.AtomicLong;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -12,15 +13,17 @@ class UuidV7Test {
 
     @Test
     void sequenceOverflowAdvancesLogicalTimestamp() throws Exception {
-        Field lastMsField = UuidV7.class.getDeclaredField("lastMs");
-        Field seqField = UuidV7.class.getDeclaredField("seq");
-        lastMsField.setAccessible(true);
-        seqField.setAccessible(true);
+        // Force the internal state to (fixedMs, seq=0x3FFE) so the next two
+        // calls hit (a) the last slot of the current ms and (b) the overflow
+        // path that advances the logical timestamp.
+        Field stateField = UuidV7.class.getDeclaredField("STATE");
+        stateField.setAccessible(true);
+        AtomicLong state = (AtomicLong) stateField.get(null);
 
+        long savedState = state.get();
         try {
             long fixedMs = System.currentTimeMillis() + 10_000L;
-            lastMsField.setLong(null, fixedMs);
-            seqField.setInt(null, 0x3FFE);
+            state.set((fixedMs << 14) | 0x3FFE);
 
             UUID lastInMs = UuidV7.next();
             UUID logicalNextMs = UuidV7.next();
@@ -28,8 +31,7 @@ class UuidV7Test {
             assertTrue(lastInMs.compareTo(logicalNextMs) < 0);
             assertEquals(timestampMs(lastInMs) + 1, timestampMs(logicalNextMs));
         } finally {
-            lastMsField.setLong(null, -1L);
-            seqField.setInt(null, 0);
+            state.set(savedState);
         }
     }
 

--- a/src/main/java/ac/grim/grimac/api/storage/backend/ApiVersion.java
+++ b/src/main/java/ac/grim/grimac/api/storage/backend/ApiVersion.java
@@ -6,8 +6,9 @@ import org.jetbrains.annotations.ApiStatus;
 public record ApiVersion(int major, int minor) implements Comparable<ApiVersion> {
 
     public static final ApiVersion V1_0 = new ApiVersion(1, 0);
+    public static final ApiVersion V2_0 = new ApiVersion(2, 0);
 
-    public static final ApiVersion CURRENT = V1_0;
+    public static final ApiVersion CURRENT = V2_0;
 
     public boolean isCompatibleWith(ApiVersion required) {
         if (this.major != required.major) return false;

--- a/src/main/java/ac/grim/grimac/api/storage/event/ViolationEvent.java
+++ b/src/main/java/ac/grim/grimac/api/storage/event/ViolationEvent.java
@@ -17,8 +17,8 @@ import java.util.UUID;
  * materialise on read from their native storage — never from an event.
  * <p>
  * Callers may pre-set {@code id()} to preserve an imported record id. Otherwise
- * the default violation sink fills it before publishing. Backends expect a
- * populated id when they receive the event.
+ * the default {@code DataStore.submit} path fills it before publishing. Backends
+ * expect a populated id when they receive the event.
  */
 @ApiStatus.Experimental
 public final class ViolationEvent {

--- a/src/main/java/ac/grim/grimac/api/storage/event/ViolationEvent.java
+++ b/src/main/java/ac/grim/grimac/api/storage/event/ViolationEvent.java
@@ -15,10 +15,18 @@ import java.util.UUID;
  * <p>
  * The immutable read-side counterpart is {@link ViolationRecord}, which backends
  * materialise on read from their native storage — never from an event.
+ * <p>
+ * The {@code id} field is optional on the event: producers MAY pre-assign a
+ * UUIDv7 (e.g. cross-backend bulk import preserving an upstream id), but the
+ * common case is to leave it null and let the sink mint one before publishing.
+ * Backends MUST honour {@code id()} if set; if null when the event reaches
+ * the backend, the backend is free to mint its own (the default sink always
+ * sets it, so the null path only triggers for bypass-the-sink test fixtures).
  */
 @ApiStatus.Experimental
 public final class ViolationEvent {
 
+    private @Nullable UUID id;
     private UUID sessionId;
     private UUID playerUuid;
     private int checkId;
@@ -26,6 +34,9 @@ public final class ViolationEvent {
     private long occurredEpochMs;
     private @Nullable String verbose;
     private VerboseFormat verboseFormat = VerboseFormat.TEXT;
+
+    public @Nullable UUID id() { return id; }
+    public @NotNull ViolationEvent id(@Nullable UUID v) { this.id = v; return this; }
 
     public @NotNull UUID sessionId() { return sessionId; }
     public @NotNull ViolationEvent sessionId(@NotNull UUID v) { this.sessionId = v; return this; }
@@ -53,6 +64,7 @@ public final class ViolationEvent {
      * without leaking fields from the previous publish.
      */
     public void reset() {
+        id = null;
         sessionId = null;
         playerUuid = null;
         checkId = 0;

--- a/src/main/java/ac/grim/grimac/api/storage/event/ViolationEvent.java
+++ b/src/main/java/ac/grim/grimac/api/storage/event/ViolationEvent.java
@@ -16,12 +16,9 @@ import java.util.UUID;
  * The immutable read-side counterpart is {@link ViolationRecord}, which backends
  * materialise on read from their native storage — never from an event.
  * <p>
- * The {@code id} field is optional on the event: producers MAY pre-assign a
- * UUIDv7 (e.g. cross-backend bulk import preserving an upstream id), but the
- * common case is to leave it null and let the sink mint one before publishing.
- * Backends MUST honour {@code id()} if set; if null when the event reaches
- * the backend, the backend is free to mint its own (the default sink always
- * sets it, so the null path only triggers for bypass-the-sink test fixtures).
+ * Callers may pre-set {@code id()} to preserve an imported record id. Otherwise
+ * the default violation sink fills it before publishing. Backends expect a
+ * populated id when they receive the event.
  */
 @ApiStatus.Experimental
 public final class ViolationEvent {

--- a/src/main/java/ac/grim/grimac/api/storage/model/ViolationRecord.java
+++ b/src/main/java/ac/grim/grimac/api/storage/model/ViolationRecord.java
@@ -7,7 +7,7 @@ import java.util.UUID;
 
 @ApiStatus.Experimental
 public record ViolationRecord(
-        long id,
+        UUID id,
         UUID sessionId,
         UUID playerUuid,
         int checkId,
@@ -17,6 +17,7 @@ public record ViolationRecord(
         VerboseFormat verboseFormat) {
 
     public ViolationRecord {
+        if (id == null) throw new IllegalArgumentException("id");
         if (sessionId == null) throw new IllegalArgumentException("sessionId");
         if (playerUuid == null) throw new IllegalArgumentException("playerUuid");
         if (verboseFormat == null) throw new IllegalArgumentException("verboseFormat");

--- a/src/main/java/ac/grim/grimac/api/storage/model/ViolationRecord.java
+++ b/src/main/java/ac/grim/grimac/api/storage/model/ViolationRecord.java
@@ -5,6 +5,12 @@ import org.jetbrains.annotations.Nullable;
 
 import java.util.UUID;
 
+/**
+ * Immutable read-side violation row. The {@code id} is a UUIDv7 generated on
+ * the write path; its timestamp prefix gives storage engines a sortable,
+ * globally unique tie-breaker while {@code occurredEpochMs} remains the event
+ * time used for history ordering.
+ */
 @ApiStatus.Experimental
 public record ViolationRecord(
         UUID id,


### PR DESCRIPTION
The per-JVM `AtomicLong` id allocator collided when multiple Grim instances shared one MongoDB (E11000 duplicate key in prod across NA-01/NA-02 sharing a replica set). Switch to producer-side UUIDv7 minted in `ViolationSinkImpl` — every backend just stores the id without coordinating, and the 48-bit unix-ms prefix keeps the unique-index B-tree append-friendly.

`UuidV7.next()` is monotonic within a single JVM (RFC 9562 §6.2 method 1 — a 14-bit per-ms counter packed across `rand_a` + `rand_b` high bits), so byte order matches mint order and the Redis backend's ZSET-by-`occurred_at` pagination stays consistent with the SQL by-id contract when several flags land in the same ms.

Per-backend migrations rebuild existing rows with replacement ids synthesised from `occurred_at`:

| Backend | Bump | Notes |
|---|---|---|
| Mongo | 5 → 6 | bulkWrite rewrite of `id` field |
| SQLite | 3 → 4 | table rebuild — SQLite can't `ALTER COLUMN TYPE` |
| MySQL | 8 → 9 | table rebuild via `RENAME` swap |
| Postgres | 7 → 8 | table rebuild, `BIGSERIAL` → `BYTEA` |
| Redis | 5 → 6 | rewrite hash keys + ZSET members |

API change gated by `@ApiStatus.Experimental` on `ViolationRecord`. `ViolationEvent.id` is optional — sink mints when null, so producer-side overrides (cross-backend bulkImport, future DB-native generators) still work.

Verified against live MySQL / Postgres / Mongo / Redis fixtures: 102/102 round-trip assertions across all backends. Plus a multi-writer Mongo test that reproduces the original bug — 1000 concurrent writes from two JVMs sharing one database, 0 E11000s, 1000 distinct ids.