### PR TITLE
storage: fix v2 SQL startup regressions

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,1 @@
-version = 1.6.0.0
+version = 1.6.0.1

--- a/grim-internal/src/main/java/ac/grim/grimac/internal/storage/backend/mongo/v2/MongoBackendV2.java
+++ b/grim-internal/src/main/java/ac/grim/grimac/internal/storage/backend/mongo/v2/MongoBackendV2.java
@@ -1,10 +1,13 @@
 package ac.grim.grimac.internal.storage.backend.mongo.v2;
 
 import ac.grim.grimac.api.storage.backend.ApiVersion;
+import ac.grim.grimac.api.storage.backend.AdminAdapter;
 import ac.grim.grimac.api.storage.backend.BackendContext;
 import ac.grim.grimac.api.storage.backend.BackendException;
 import ac.grim.grimac.api.storage.backend.BackendV2;
 import ac.grim.grimac.api.storage.backend.KindAdapter;
+import ac.grim.grimac.api.storage.backend.SearchAdapter;
+import ac.grim.grimac.api.storage.backend.TxAdapter;
 import ac.grim.grimac.api.storage.category.Capability;
 import ac.grim.grimac.api.storage.kind.Counter;
 import ac.grim.grimac.api.storage.kind.DataKind;
@@ -122,6 +125,10 @@ public final class MongoBackendV2 implements BackendV2 {
         // Blob lands in Phase 6.
         return Optional.empty();
     }
+
+    @Override public @NotNull Optional<SearchAdapter> searchAdapter() { return Optional.empty(); }
+    @Override public @NotNull Optional<TxAdapter> txAdapter() { return Optional.empty(); }
+    @Override public @NotNull Optional<AdminAdapter> adminAdapter() { return Optional.empty(); }
 
     @Override
     @SuppressWarnings("unchecked")

--- a/grim-internal/src/main/java/ac/grim/grimac/internal/storage/backend/mysql/v2/MysqlBackendV2.java
+++ b/grim-internal/src/main/java/ac/grim/grimac/internal/storage/backend/mysql/v2/MysqlBackendV2.java
@@ -100,6 +100,11 @@ public final class MysqlBackendV2 implements BackendV2 {
         if (kind instanceof Counter<?>)              return Optional.of((KindAdapter) counterAdapter);
         return Optional.empty();
     }
+
+    @Override public @NotNull Optional<SearchAdapter> searchAdapter() { return Optional.empty(); }
+    @Override public @NotNull Optional<TxAdapter> txAdapter() { return Optional.empty(); }
+    @Override public @NotNull Optional<AdminAdapter> adminAdapter() { return Optional.empty(); }
+
     @Override @SuppressWarnings("unchecked")
     public <X> @NotNull Optional<X> unwrap(@NotNull Class<X> type) {
         if (type.isAssignableFrom(javax.sql.DataSource.class) && ds != null) return Optional.of((X) ds);

--- a/grim-internal/src/main/java/ac/grim/grimac/internal/storage/backend/postgres/v2/PostgresBackendV2.java
+++ b/grim-internal/src/main/java/ac/grim/grimac/internal/storage/backend/postgres/v2/PostgresBackendV2.java
@@ -1,10 +1,13 @@
 package ac.grim.grimac.internal.storage.backend.postgres.v2;
 
 import ac.grim.grimac.api.storage.backend.ApiVersion;
+import ac.grim.grimac.api.storage.backend.AdminAdapter;
 import ac.grim.grimac.api.storage.backend.BackendContext;
 import ac.grim.grimac.api.storage.backend.BackendException;
 import ac.grim.grimac.api.storage.backend.BackendV2;
 import ac.grim.grimac.api.storage.backend.KindAdapter;
+import ac.grim.grimac.api.storage.backend.SearchAdapter;
+import ac.grim.grimac.api.storage.backend.TxAdapter;
 import ac.grim.grimac.api.storage.category.Capability;
 import ac.grim.grimac.api.storage.kind.Counter;
 import ac.grim.grimac.api.storage.kind.DataKind;
@@ -191,6 +194,10 @@ public final class PostgresBackendV2 implements BackendV2 {
         if (kind instanceof Counter<?>)                 return Optional.of((KindAdapter) counterAdapter);
         return Optional.empty();
     }
+
+    @Override public @NotNull Optional<SearchAdapter> searchAdapter() { return Optional.empty(); }
+    @Override public @NotNull Optional<TxAdapter> txAdapter() { return Optional.empty(); }
+    @Override public @NotNull Optional<AdminAdapter> adminAdapter() { return Optional.empty(); }
 
     @Override
     @SuppressWarnings("unchecked")

--- a/grim-internal/src/main/java/ac/grim/grimac/internal/storage/backend/redis/v2/RedisBackendV2.java
+++ b/grim-internal/src/main/java/ac/grim/grimac/internal/storage/backend/redis/v2/RedisBackendV2.java
@@ -93,6 +93,11 @@ public final class RedisBackendV2 implements BackendV2 {
         if (kind instanceof Counter<?>)              return Optional.of((KindAdapter) counterAdapter);
         return Optional.empty();
     }
+
+    @Override public @NotNull Optional<SearchAdapter> searchAdapter() { return Optional.empty(); }
+    @Override public @NotNull Optional<TxAdapter> txAdapter() { return Optional.empty(); }
+    @Override public @NotNull Optional<AdminAdapter> adminAdapter() { return Optional.empty(); }
+
     @Override @SuppressWarnings("unchecked")
     public <X> @NotNull Optional<X> unwrap(@NotNull Class<X> type) {
         if (type.isAssignableFrom(JedisPool.class) && pool != null) return Optional.of((X) pool);

--- a/grim-internal/src/main/java/ac/grim/grimac/internal/storage/backend/sql/v2/SqlKeyValueScopedAdapter.java
+++ b/grim-internal/src/main/java/ac/grim/grimac/internal/storage/backend/sql/v2/SqlKeyValueScopedAdapter.java
@@ -68,13 +68,18 @@ public final class SqlKeyValueScopedAdapter implements KindAdapter<KeyValueScope
     @Override
     public void ensureStore(@NotNull StoreId id, @NotNull KeyValueScoped<?, ?> kind) throws BackendException {
         String table = dialect.quoteIdentifier(id.name());
+        String scope = dialect.quoteIdentifier("scope");
+        String scopeKey = dialect.quoteIdentifier("scope_key");
+        String key = dialect.quoteIdentifier("key");
+        String value = dialect.quoteIdentifier("value");
+        String updatedAt = dialect.quoteIdentifier("updated_at");
         String ddl = "CREATE TABLE IF NOT EXISTS " + table + " ("
-            + "scope VARCHAR(64) NOT NULL, "
-            + "scope_key VARCHAR(255) NOT NULL, "
-            + "key VARCHAR(255) NOT NULL, "
-            + "value " + dialect.kvValueColumnType() + ", "
-            + "updated_at BIGINT NOT NULL DEFAULT 0, "
-            + "PRIMARY KEY (scope, scope_key, key))";
+            + scope + " VARCHAR(64) NOT NULL, "
+            + scopeKey + " VARCHAR(255) NOT NULL, "
+            + key + " VARCHAR(255) NOT NULL, "
+            + value + " " + dialect.kvValueColumnType() + ", "
+            + updatedAt + " BIGINT NOT NULL DEFAULT 0, "
+            + "PRIMARY KEY (" + scope + ", " + scopeKey + ", " + key + "))";
         try (Connection c = ds.getConnection(); Statement s = c.createStatement()) {
             s.executeUpdate(ddl);
         } catch (SQLException e) {
@@ -96,7 +101,10 @@ public final class SqlKeyValueScopedAdapter implements KindAdapter<KeyValueScope
             @NotNull StoreId id, @NotNull KeyValueScoped<?, ?> kind, @NotNull Category<E> category) {
         String table = dialect.quoteIdentifier(id.name());
         String upsertSql = dialect.kvUpsertSql(table);
-        String deleteSql = "DELETE FROM " + table + " WHERE scope = ? AND scope_key = ? AND key = ?";
+        String deleteSql = "DELETE FROM " + table
+            + " WHERE " + dialect.quoteIdentifier("scope") + " = ?"
+            + " AND " + dialect.quoteIdentifier("scope_key") + " = ?"
+            + " AND " + dialect.quoteIdentifier("key") + " = ?";
         return new KVWriteHandler<>(upsertSql, deleteSql);
     }
 
@@ -186,13 +194,16 @@ public final class SqlKeyValueScopedAdapter implements KindAdapter<KeyValueScope
         String table = dialect.quoteIdentifier(id.name());
         try (Connection c = ds.getConnection();
              PreparedStatement ps = c.prepareStatement(
-                 "SELECT value FROM " + table + " WHERE scope = ? AND scope_key = ? AND key = ?")) {
+                 "SELECT " + dialect.quoteIdentifier("value") + " FROM " + table
+                     + " WHERE " + dialect.quoteIdentifier("scope") + " = ?"
+                     + " AND " + dialect.quoteIdentifier("scope_key") + " = ?"
+                     + " AND " + dialect.quoteIdentifier("key") + " = ?")) {
             ps.setString(1, String.valueOf(op.scope()));
             ps.setString(2, String.valueOf(op.scopeKey()));
             ps.setString(3, op.key());
             try (ResultSet rs = ps.executeQuery()) {
                 if (!rs.next()) return Optional.empty();
-                byte[] v = rs.getBytes("value");
+                byte[] v = rs.getBytes(1);
                 return v == null ? Optional.empty() : Optional.of(v);
             }
         }
@@ -204,13 +215,16 @@ public final class SqlKeyValueScopedAdapter implements KindAdapter<KeyValueScope
         Map<String, Object> out = new LinkedHashMap<>();
         try (Connection c = ds.getConnection();
              PreparedStatement ps = c.prepareStatement(
-                 "SELECT key, value FROM " + table + " WHERE scope = ? AND scope_key = ?")) {
+                 "SELECT " + dialect.quoteIdentifier("key") + ", " + dialect.quoteIdentifier("value")
+                     + " FROM " + table
+                     + " WHERE " + dialect.quoteIdentifier("scope") + " = ?"
+                     + " AND " + dialect.quoteIdentifier("scope_key") + " = ?")) {
             ps.setString(1, String.valueOf(op.scope()));
             ps.setString(2, String.valueOf(op.scopeKey()));
             try (ResultSet rs = ps.executeQuery()) {
                 while (rs.next()) {
-                    byte[] v = rs.getBytes("value");
-                    if (v != null) out.put(rs.getString("key"), v);
+                    byte[] v = rs.getBytes(2);
+                    if (v != null) out.put(rs.getString(1), v);
                 }
             }
         }
@@ -267,7 +281,10 @@ public final class SqlKeyValueScopedAdapter implements KindAdapter<KeyValueScope
         String table = dialect.quoteIdentifier(id.name());
         try (Connection c = ds.getConnection();
              PreparedStatement ps = c.prepareStatement(
-                 "DELETE FROM " + table + " WHERE scope = ? AND scope_key = ? AND key = ?")) {
+                 "DELETE FROM " + table
+                     + " WHERE " + dialect.quoteIdentifier("scope") + " = ?"
+                     + " AND " + dialect.quoteIdentifier("scope_key") + " = ?"
+                     + " AND " + dialect.quoteIdentifier("key") + " = ?")) {
             ps.setString(1, String.valueOf(op.scope()));
             ps.setString(2, String.valueOf(op.scopeKey()));
             ps.setString(3, op.key());
@@ -279,7 +296,9 @@ public final class SqlKeyValueScopedAdapter implements KindAdapter<KeyValueScope
         String table = dialect.quoteIdentifier(id.name());
         try (Connection c = ds.getConnection();
              PreparedStatement ps = c.prepareStatement(
-                 "DELETE FROM " + table + " WHERE scope = ? AND scope_key = ?")) {
+                 "DELETE FROM " + table
+                     + " WHERE " + dialect.quoteIdentifier("scope") + " = ?"
+                     + " AND " + dialect.quoteIdentifier("scope_key") + " = ?")) {
             ps.setString(1, String.valueOf(op.scope()));
             ps.setString(2, String.valueOf(op.scopeKey()));
             ps.executeUpdate();
@@ -290,7 +309,9 @@ public final class SqlKeyValueScopedAdapter implements KindAdapter<KeyValueScope
         String table = dialect.quoteIdentifier(id.name());
         try (Connection c = ds.getConnection();
              PreparedStatement ps = c.prepareStatement(
-                 "SELECT COUNT(*) FROM " + table + " WHERE scope = ? AND scope_key = ?")) {
+                 "SELECT COUNT(*) FROM " + table
+                     + " WHERE " + dialect.quoteIdentifier("scope") + " = ?"
+                     + " AND " + dialect.quoteIdentifier("scope_key") + " = ?")) {
             ps.setString(1, String.valueOf(op.scope()));
             ps.setString(2, String.valueOf(op.scopeKey()));
             try (ResultSet rs = ps.executeQuery()) {

--- a/grim-internal/src/main/java/ac/grim/grimac/internal/storage/backend/sql/v2/dialect/SqlDialect.java
+++ b/grim-internal/src/main/java/ac/grim/grimac/internal/storage/backend/sql/v2/dialect/SqlDialect.java
@@ -161,9 +161,16 @@ public interface SqlDialect {
      * ON CONFLICT syntax. MySQL overrides with ON DUPLICATE KEY UPDATE.
      */
     default @NotNull String kvUpsertSql(@NotNull String quotedTable) {
-        return "INSERT INTO " + quotedTable + " (scope, scope_key, key, value, updated_at) "
+        String scope = quoteIdentifier("scope");
+        String scopeKey = quoteIdentifier("scope_key");
+        String key = quoteIdentifier("key");
+        String value = quoteIdentifier("value");
+        String updatedAt = quoteIdentifier("updated_at");
+        return "INSERT INTO " + quotedTable + " (" + scope + ", " + scopeKey + ", " + key
+            + ", " + value + ", " + updatedAt + ") "
             + "VALUES (?, ?, ?, ?, ?) "
-            + "ON CONFLICT (scope, scope_key, key) DO UPDATE SET value = " + excludedRef(quoteIdentifier("value"))
-            + ", updated_at = " + excludedRef(quoteIdentifier("updated_at"));
+            + "ON CONFLICT (" + scope + ", " + scopeKey + ", " + key + ") DO UPDATE SET "
+            + value + " = " + excludedRef(value)
+            + ", " + updatedAt + " = " + excludedRef(updatedAt);
     }
 }

--- a/grim-internal/src/main/java/ac/grim/grimac/internal/storage/backend/sqlite/v2/SqliteBackendV2.java
+++ b/grim-internal/src/main/java/ac/grim/grimac/internal/storage/backend/sqlite/v2/SqliteBackendV2.java
@@ -13,6 +13,8 @@ import ac.grim.grimac.internal.storage.backend.sql.v2.dialect.SqliteDialect;
 import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
 
+import java.io.IOException;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.sql.Connection;
 import java.sql.DriverManager;
@@ -69,6 +71,19 @@ public final class SqliteBackendV2 implements BackendV2 {
         Path dbFile = ctx.dataDirectory().resolve(config.path());
         String jdbcUrl = "jdbc:sqlite:" + dbFile.toAbsolutePath();
         try {
+            Class.forName("org.sqlite.JDBC");
+        } catch (ClassNotFoundException e) {
+            throw new BackendException("SQLite JDBC driver missing: " + e.getMessage(), e);
+        }
+        Path parent = dbFile.getParent();
+        if (parent != null) {
+            try {
+                Files.createDirectories(parent);
+            } catch (IOException e) {
+                throw new BackendException("failed to create SQLite database directory " + parent, e);
+            }
+        }
+        try {
             this.connection = DriverManager.getConnection(jdbcUrl);
             try (Statement s = connection.createStatement()) {
                 s.execute("PRAGMA journal_mode=WAL");
@@ -109,6 +124,11 @@ public final class SqliteBackendV2 implements BackendV2 {
         if (kind instanceof Counter<?>)              return Optional.of((KindAdapter) counterAdapter);
         return Optional.empty();
     }
+
+    @Override public @NotNull Optional<SearchAdapter> searchAdapter() { return Optional.empty(); }
+    @Override public @NotNull Optional<TxAdapter> txAdapter() { return Optional.empty(); }
+    @Override public @NotNull Optional<AdminAdapter> adminAdapter() { return Optional.empty(); }
+
     @Override @SuppressWarnings("unchecked")
     public <X> @NotNull Optional<X> unwrap(@NotNull Class<X> type) {
         if (type.isAssignableFrom(javax.sql.DataSource.class) && singleConnDs != null) return Optional.of((X) singleConnDs);

--- a/grim-internal/src/test/java/ac/grim/grimac/internal/storage/backend/V2BackendIntegrationTest.java
+++ b/grim-internal/src/test/java/ac/grim/grimac/internal/storage/backend/V2BackendIntegrationTest.java
@@ -6,13 +6,17 @@ import ac.grim.grimac.api.storage.backend.BackendV2;
 import ac.grim.grimac.api.storage.backend.KindAdapter;
 import ac.grim.grimac.api.storage.category.Categories;
 import ac.grim.grimac.api.storage.config.TableNames;
+import ac.grim.grimac.api.storage.event.SettingEvent;
 import ac.grim.grimac.api.storage.event.ServerStartupEvent;
 import ac.grim.grimac.api.storage.event.SessionEvent;
 import ac.grim.grimac.api.storage.kind.Entity;
+import ac.grim.grimac.api.storage.kind.KeyValueScoped;
 import ac.grim.grimac.api.storage.kind.ops.EntityOps;
+import ac.grim.grimac.api.storage.kind.ops.KeyValueScopedOps;
 import ac.grim.grimac.api.storage.model.PlayerIdentity;
 import ac.grim.grimac.api.storage.model.ServerStartupRecord;
 import ac.grim.grimac.api.storage.model.SessionRecord;
+import ac.grim.grimac.api.storage.model.SettingScope;
 import ac.grim.grimac.api.storage.registry.StoreId;
 import ac.grim.grimac.internal.storage.backend.mongo.MongoBackendConfig;
 import ac.grim.grimac.internal.storage.backend.mongo.v2.MongoBackendV2;
@@ -29,6 +33,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
 import java.net.Socket;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Optional;
 import java.util.UUID;
@@ -48,12 +53,15 @@ class V2BackendIntegrationTest {
 
     @Test @DisplayName("SQLite v2: entity indexes")
     void sqlite(@TempDir Path tempDir) throws Exception {
-        SqliteBackendConfig cfg = SqliteBackendConfig.defaults("v2-integ.db");
+        SqliteBackendConfig cfg = SqliteBackendConfig.defaults("data/v2-integ.db");
         SqliteBackendV2 backend = new SqliteBackendV2(cfg);
         try {
             backend.init(ctx(cfg, tempDir));
+            assertTrue(Files.isDirectory(tempDir.resolve("data")),
+                    "SQLite backend creates missing parent directories");
             exerciseEntityIndexes(backend, "v2_integ_players_sqlite", "v2_integ_sessions_sqlite",
                     "v2_integ_startups_sqlite");
+            exerciseSettingsKv(backend, "v2_integ_settings_sqlite");
         } finally {
             backend.close();
         }
@@ -254,6 +262,32 @@ class V2BackendIntegrationTest {
             backend.id() + ": by_open_heartbeat excludes closed startup");
 
         LOG.info(() -> backend.id() + ": v2 entity index contract OK for " + testUuid);
+    }
+
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    private void exerciseSettingsKv(BackendV2 backend, String settingsStoreName) throws Exception {
+        StoreId settingsStore = StoreId.grim(settingsStoreName + "_" + Long.toHexString(System.nanoTime()));
+        KeyValueScoped settingsKind = V2BuiltinKinds.settings();
+        KindAdapter adapter = backend.adapterFor(settingsKind).orElseThrow(
+            () -> new AssertionError(backend.id() + " has no KeyValueScoped adapter"));
+
+        adapter.ensureStore(settingsStore, settingsKind);
+
+        var handler = adapter.writeHandler(settingsStore, settingsKind, Categories.SETTING);
+        SettingEvent event = new SettingEvent();
+        event.scope(SettingScope.PLAYER)
+            .scopeKey("00000000-0000-0000-0000-000000000001")
+            .key("alerts")
+            .value(new byte[]{1})
+            .updatedEpochMs(System.currentTimeMillis());
+        handler.onEvent(event, 0, true);
+
+        KeyValueScopedOps.GetOp<SettingScope, byte[]> get = new KeyValueScopedOps.GetOp<>(
+            Categories.SETTING, SettingScope.PLAYER,
+            "00000000-0000-0000-0000-000000000001", "alerts");
+        Optional<byte[]> got = (Optional<byte[]>) adapter.execute(settingsStore, settingsKind, get);
+        assertTrue(got.isPresent(), backend.id() + ": setting KV row round-trips");
+        assertArrayEquals(new byte[]{1}, got.get(), backend.id() + ": setting KV value round-trips");
     }
 
     private static void writeSession(ac.grim.grimac.api.storage.backend.StorageEventHandler<SessionEvent> handler,

--- a/grim-internal/src/test/java/ac/grim/grimac/internal/storage/backend/sql/v2/SqlKeyValueScopedAdapterTest.java
+++ b/grim-internal/src/test/java/ac/grim/grimac/internal/storage/backend/sql/v2/SqlKeyValueScopedAdapterTest.java
@@ -1,0 +1,92 @@
+package ac.grim.grimac.internal.storage.backend.sql.v2;
+
+import ac.grim.grimac.api.storage.registry.StoreId;
+import ac.grim.grimac.internal.storage.backend.sql.v2.dialect.MysqlDialect;
+import ac.grim.grimac.internal.storage.category.V2BuiltinKinds;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import javax.sql.DataSource;
+import java.io.PrintWriter;
+import java.lang.reflect.InvocationHandler;
+import java.lang.reflect.Proxy;
+import java.sql.Connection;
+import java.sql.Statement;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.logging.Logger;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class SqlKeyValueScopedAdapterTest {
+
+    @Test
+    @DisplayName("MySQL KV DDL quotes the reserved key column")
+    void mysqlDdlQuotesReservedKeyColumn() throws Exception {
+        CapturingDataSource ds = new CapturingDataSource();
+        SqlKeyValueScopedAdapter adapter = new SqlKeyValueScopedAdapter(
+            ds, new MysqlDialect(), Logger.getLogger("sql-kv-test"));
+
+        adapter.ensureStore(StoreId.grim("grim_settings"), V2BuiltinKinds.settings());
+
+        String ddl = ds.sql();
+        assertTrue(ddl.contains("`key` VARCHAR(255) NOT NULL"), ddl);
+        assertTrue(ddl.contains("PRIMARY KEY (`scope`, `scope_key`, `key`)"), ddl);
+        assertFalse(ddl.contains(" key VARCHAR"), ddl);
+    }
+
+    private static final class CapturingDataSource implements DataSource {
+        private final AtomicReference<String> sql = new AtomicReference<>();
+
+        String sql() {
+            return sql.get();
+        }
+
+        @Override public Connection getConnection() {
+            Statement statement = proxy(Statement.class, (proxy, method, args) -> {
+                if (method.getName().equals("executeUpdate") && args != null && args.length == 1) {
+                    sql.set((String) args[0]);
+                    return 0;
+                }
+                return defaultValue(method.getReturnType());
+            });
+            return proxy(Connection.class, (proxy, method, args) -> switch (method.getName()) {
+                case "createStatement" -> statement;
+                case "isClosed" -> false;
+                default -> defaultValue(method.getReturnType());
+            });
+        }
+
+        @Override public Connection getConnection(String username, String password) {
+            return getConnection();
+        }
+
+        @Override public PrintWriter getLogWriter() { return null; }
+        @Override public void setLogWriter(PrintWriter out) {}
+        @Override public void setLoginTimeout(int seconds) {}
+        @Override public int getLoginTimeout() { return 0; }
+        @Override public java.util.logging.Logger getParentLogger() {
+            return java.util.logging.Logger.getGlobal();
+        }
+        @Override public <T> T unwrap(Class<T> iface) { return null; }
+        @Override public boolean isWrapperFor(Class<?> iface) { return false; }
+    }
+
+    @SuppressWarnings("unchecked")
+    private static <T> T proxy(Class<T> type, InvocationHandler handler) {
+        return (T) Proxy.newProxyInstance(type.getClassLoader(), new Class<?>[]{type}, handler);
+    }
+
+    private static Object defaultValue(Class<?> type) {
+        if (type == void.class) return null;
+        if (type == boolean.class) return false;
+        if (type == byte.class) return (byte) 0;
+        if (type == short.class) return (short) 0;
+        if (type == int.class) return 0;
+        if (type == long.class) return 0L;
+        if (type == float.class) return 0F;
+        if (type == double.class) return 0D;
+        if (type == char.class) return '\0';
+        return null;
+    }
+}

--- a/grim-internal/src/test/java/ac/grim/grimac/internal/storage/core/V2RoutesBuilderTest.java
+++ b/grim-internal/src/test/java/ac/grim/grimac/internal/storage/core/V2RoutesBuilderTest.java
@@ -1,7 +1,7 @@
 package ac.grim.grimac.internal.storage.core;
 
-import ac.grim.grimac.api.storage.backend.AdminAdapter;
 import ac.grim.grimac.api.storage.backend.ApiVersion;
+import ac.grim.grimac.api.storage.backend.AdminAdapter;
 import ac.grim.grimac.api.storage.backend.BackendContext;
 import ac.grim.grimac.api.storage.backend.BackendException;
 import ac.grim.grimac.api.storage.backend.BackendV2;

--- a/src/main/java/ac/grim/grimac/api/storage/admin/CollectionStats.java
+++ b/src/main/java/ac/grim/grimac/api/storage/admin/CollectionStats.java
@@ -1,0 +1,12 @@
+package ac.grim.grimac.api.storage.admin;
+
+import org.jetbrains.annotations.ApiStatus;
+
+@ApiStatus.Experimental
+public record CollectionStats(
+        long documentCount,
+        long storageBytes,
+        long dataBytes,
+        long indexBytes,
+        double compressionRatio) {
+}

--- a/src/main/java/ac/grim/grimac/api/storage/admin/ExplainPlan.java
+++ b/src/main/java/ac/grim/grimac/api/storage/admin/ExplainPlan.java
@@ -1,0 +1,32 @@
+package ac.grim.grimac.api.storage.admin;
+
+import org.jetbrains.annotations.ApiStatus;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.time.Duration;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Normalized explain-plan tree across backends. The {@link #raw()} blob
+ * preserves backend-specific detail (Mongo {@code explain('executionStats')},
+ * Postgres {@code EXPLAIN (FORMAT JSON, ANALYZE)}, etc.) for power users.
+ */
+@ApiStatus.Experimental
+public record ExplainPlan(
+        @NotNull String stage,
+        long rowsExamined,
+        long rowsReturned,
+        @NotNull Duration estimatedTime,
+        @Nullable String indexUsed,
+        @NotNull Map<String, Object> details,
+        @NotNull List<ExplainPlan> children,
+        @NotNull Map<String, Object> raw) {
+
+    public ExplainPlan {
+        details = Map.copyOf(details);
+        children = List.copyOf(children);
+        raw = Map.copyOf(raw);
+    }
+}

--- a/src/main/java/ac/grim/grimac/api/storage/admin/IndexStats.java
+++ b/src/main/java/ac/grim/grimac/api/storage/admin/IndexStats.java
@@ -1,0 +1,20 @@
+package ac.grim.grimac.api.storage.admin;
+
+import org.jetbrains.annotations.ApiStatus;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.List;
+
+@ApiStatus.Experimental
+public record IndexStats(@NotNull List<Entry> entries) {
+
+    public IndexStats {
+        entries = List.copyOf(entries);
+    }
+
+    public record Entry(
+            @NotNull String name,
+            long sizeBytes,
+            long entryCount,
+            double usageRate) {}
+}

--- a/src/main/java/ac/grim/grimac/api/storage/backend/AdminAdapter.java
+++ b/src/main/java/ac/grim/grimac/api/storage/backend/AdminAdapter.java
@@ -1,0 +1,34 @@
+package ac.grim.grimac.api.storage.backend;
+
+import ac.grim.grimac.api.storage.admin.CollectionStats;
+import ac.grim.grimac.api.storage.admin.ExplainPlan;
+import ac.grim.grimac.api.storage.admin.IndexStats;
+import ac.grim.grimac.api.storage.kind.Operation;
+import ac.grim.grimac.api.storage.registry.StoreId;
+import ac.grim.grimac.api.storage.search.SearchSpec;
+import org.jetbrains.annotations.ApiStatus;
+import org.jetbrains.annotations.NotNull;
+
+import java.time.Duration;
+
+/**
+ * Per-backend admin SPI. Synchronous; called from the reader pool by the
+ * {@code AdminAccess} facade.
+ */
+@ApiStatus.Experimental
+public interface AdminAdapter {
+
+    @NotNull ExplainPlan explain(@NotNull StoreId id, @NotNull Operation<?> op) throws BackendException;
+
+    @NotNull ExplainPlan explainSearch(@NotNull StoreId id, @NotNull SearchSpec spec) throws BackendException;
+
+    void reindex(@NotNull StoreId id) throws BackendException;
+
+    void rebuildSearchIndex(@NotNull StoreId id) throws BackendException;
+
+    void setRetention(@NotNull StoreId id, @NotNull Duration retention) throws BackendException;
+
+    @NotNull IndexStats indexStats(@NotNull StoreId id) throws BackendException;
+
+    @NotNull CollectionStats collectionStats(@NotNull StoreId id) throws BackendException;
+}

--- a/src/main/java/ac/grim/grimac/api/storage/backend/BackendV2.java
+++ b/src/main/java/ac/grim/grimac/api/storage/backend/BackendV2.java
@@ -12,7 +12,8 @@ import java.util.Optional;
 /**
  * Narrow storage-engine SPI replacing the old {@link Backend}. Owns
  * connection lifecycle and capability advertisement; per-Kind work is
- * delegated to {@link KindAdapter}.
+ * delegated to {@link KindAdapter}; transactions / search / admin live
+ * behind optional capability adapters.
  * <p>
  * Coexists with the legacy {@link Backend} during the redesign window.
  * Phase 5 deletes the old SPI and renames this to {@code Backend}.
@@ -39,10 +40,17 @@ public interface BackendV2 {
      */
     <K extends DataKind<?, ?>> @NotNull Optional<KindAdapter<K>> adapterFor(@NotNull K kind);
 
+    @NotNull Optional<SearchAdapter> searchAdapter();
+
+    @NotNull Optional<TxAdapter> txAdapter();
+
+    @NotNull Optional<AdminAdapter> adminAdapter();
+
     /**
      * Last-resort escape hatch. Returns the underlying client (e.g.
      * {@code MongoDatabase}, {@code java.sql.Connection}, {@code Jedis}) for
-     * callers that have no portable alternative.
+     * extensions that have called {@code requireBackend(...)} and have no
+     * portable alternative. See {@code .docs/storage-redesign/04-search-tx-admin.md}.
      */
     <X> @NotNull Optional<X> unwrap(@NotNull Class<X> type);
 

--- a/src/main/java/ac/grim/grimac/api/storage/backend/SearchAdapter.java
+++ b/src/main/java/ac/grim/grimac/api/storage/backend/SearchAdapter.java
@@ -1,0 +1,30 @@
+package ac.grim.grimac.api.storage.backend;
+
+import ac.grim.grimac.api.storage.category.Capability;
+import ac.grim.grimac.api.storage.codec.EncodeShape;
+import ac.grim.grimac.api.storage.registry.StoreId;
+import ac.grim.grimac.api.storage.search.SearchResult;
+import ac.grim.grimac.api.storage.search.SearchSpec;
+import org.jetbrains.annotations.ApiStatus;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.EnumSet;
+
+/**
+ * Per-backend search SPI. Composed into {@link KindAdapter#ensureStore} for
+ * categories that declare {@code @Searchable} fields; consulted by
+ * {@code DataStore.search} for query execution.
+ */
+@ApiStatus.Experimental
+public interface SearchAdapter {
+
+    @NotNull EnumSet<Capability> searchCapabilities();
+
+    /** Create the search index for a store, given its codec shape. Idempotent. */
+    void ensureSearchIndex(@NotNull StoreId id, @NotNull EncodeShape shape) throws BackendException;
+
+    void rebuildIndex(@NotNull StoreId id) throws BackendException;
+
+    <R> @NotNull SearchResult<R> execute(@NotNull StoreId id, @NotNull EncodeShape shape,
+                                         @NotNull SearchSpec spec) throws BackendException;
+}

--- a/src/main/java/ac/grim/grimac/api/storage/backend/TxAdapter.java
+++ b/src/main/java/ac/grim/grimac/api/storage/backend/TxAdapter.java
@@ -1,0 +1,28 @@
+package ac.grim.grimac.api.storage.backend;
+
+import ac.grim.grimac.api.storage.category.Capability;
+import ac.grim.grimac.api.storage.tx.TxBody;
+import ac.grim.grimac.api.storage.tx.TxScope;
+import org.jetbrains.annotations.ApiStatus;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.EnumSet;
+
+/**
+ * Per-backend transaction SPI. Implementations execute the body atomically:
+ * SQL via {@code Connection.autoCommit(false)}, Mongo via
+ * {@code session.withTransaction}, Redis via Lua compilation.
+ */
+@ApiStatus.Experimental
+public interface TxAdapter {
+
+    @NotNull EnumSet<Capability> txCapabilities();
+
+    /**
+     * Run the body atomically. If {@code scope} is null, the implementation
+     * must advertise {@code TX_GLOBAL}; otherwise it must advertise
+     * {@code TX_LOCAL} (or {@code TX_GLOBAL}).
+     */
+    <T> T run(@Nullable TxScope scope, @NotNull TxBody<T> body) throws Exception;
+}

--- a/src/main/java/ac/grim/grimac/api/storage/search/Direction.java
+++ b/src/main/java/ac/grim/grimac/api/storage/search/Direction.java
@@ -1,0 +1,8 @@
+package ac.grim.grimac.api.storage.search;
+
+import org.jetbrains.annotations.ApiStatus;
+
+@ApiStatus.Experimental
+public enum Direction {
+    ASC, DESC
+}

--- a/src/main/java/ac/grim/grimac/api/storage/search/FacetResult.java
+++ b/src/main/java/ac/grim/grimac/api/storage/search/FacetResult.java
@@ -1,0 +1,26 @@
+package ac.grim.grimac.api.storage.search;
+
+import org.jetbrains.annotations.ApiStatus;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.List;
+
+/**
+ * Faceting result for one declared {@link FacetType}. Buckets carry the
+ * facet value (term, histogram-bin midpoint, range label) and the document
+ * count; histogram facets additionally expose lower / upper edges.
+ */
+@ApiStatus.Experimental
+public record FacetResult(@NotNull FacetType type, @NotNull List<Bucket> buckets) {
+
+    public FacetResult {
+        buckets = List.copyOf(buckets);
+    }
+
+    public record Bucket(
+            @NotNull Object value,
+            long count,
+            @Nullable Double lowerBound,
+            @Nullable Double upperBound) {}
+}

--- a/src/main/java/ac/grim/grimac/api/storage/search/FacetType.java
+++ b/src/main/java/ac/grim/grimac/api/storage/search/FacetType.java
@@ -1,0 +1,15 @@
+package ac.grim.grimac.api.storage.search;
+
+import org.jetbrains.annotations.ApiStatus;
+
+@ApiStatus.Experimental
+public enum FacetType {
+    /** Group by distinct term values, top-N. */
+    TERMS,
+    /** Numeric histogram with fixed bucket width. */
+    HISTOGRAM,
+    /** Date histogram with calendar-aware bucketing. */
+    DATE_HISTOGRAM,
+    /** Pre-declared numeric ranges. */
+    RANGE
+}

--- a/src/main/java/ac/grim/grimac/api/storage/search/FilterOp.java
+++ b/src/main/java/ac/grim/grimac/api/storage/search/FilterOp.java
@@ -1,0 +1,8 @@
+package ac.grim.grimac.api.storage.search;
+
+import org.jetbrains.annotations.ApiStatus;
+
+@ApiStatus.Experimental
+public enum FilterOp {
+    EQ, NEQ, GT, GTE, LT, LTE, IN, RANGE, EXISTS
+}

--- a/src/main/java/ac/grim/grimac/api/storage/search/HistogramParams.java
+++ b/src/main/java/ac/grim/grimac/api/storage/search/HistogramParams.java
@@ -1,0 +1,19 @@
+package ac.grim.grimac.api.storage.search;
+
+import org.jetbrains.annotations.ApiStatus;
+
+/**
+ * Parameters for a {@link FacetType#HISTOGRAM} facet.
+ *
+ * @param min       inclusive lower bound of bucket 0
+ * @param max       exclusive upper bound of the last bucket
+ * @param buckets   number of equal-width buckets between min and max
+ */
+@ApiStatus.Experimental
+public record HistogramParams(double min, double max, int buckets) {
+
+    public HistogramParams {
+        if (buckets <= 0) throw new IllegalArgumentException("buckets > 0");
+        if (max <= min) throw new IllegalArgumentException("max > min");
+    }
+}

--- a/src/main/java/ac/grim/grimac/api/storage/search/MatchMode.java
+++ b/src/main/java/ac/grim/grimac/api/storage/search/MatchMode.java
@@ -1,0 +1,17 @@
+package ac.grim.grimac.api.storage.search;
+
+import org.jetbrains.annotations.ApiStatus;
+
+@ApiStatus.Experimental
+public enum MatchMode {
+    /** Term match against the analyzed field. */
+    TERM,
+    /** Whole phrase. */
+    PHRASE,
+    /** Phrase with last token treated as prefix. */
+    PHRASE_PREFIX,
+    /** Levenshtein fuzzy. Requires {@code SEARCH_FUZZY}. */
+    FUZZY,
+    /** Glob/wildcard. */
+    WILDCARD
+}

--- a/src/main/java/ac/grim/grimac/api/storage/search/Range.java
+++ b/src/main/java/ac/grim/grimac/api/storage/search/Range.java
@@ -1,0 +1,20 @@
+package ac.grim.grimac.api.storage.search;
+
+import org.jetbrains.annotations.ApiStatus;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+/**
+ * Inclusive range value for {@link FilterOp#RANGE} filters. Either bound may
+ * be null for half-open ranges.
+ */
+@ApiStatus.Experimental
+public record Range(@Nullable Object from, @Nullable Object to) {
+
+    public static @NotNull Range of(@Nullable Object from, @Nullable Object to) {
+        return new Range(from, to);
+    }
+
+    public static @NotNull Range atLeast(@NotNull Object from) { return new Range(from, null); }
+    public static @NotNull Range atMost(@NotNull Object to)    { return new Range(null, to); }
+}

--- a/src/main/java/ac/grim/grimac/api/storage/search/Rank.java
+++ b/src/main/java/ac/grim/grimac/api/storage/search/Rank.java
@@ -1,0 +1,15 @@
+package ac.grim.grimac.api.storage.search;
+
+import org.jetbrains.annotations.ApiStatus;
+
+@ApiStatus.Experimental
+public enum Rank {
+    /** BM25 (Lucene-family default). */
+    BM25,
+    /** Classic TF-IDF (Postgres ts_rank, MySQL default). */
+    TFIDF,
+    /** Backend's default native scoring. */
+    NATIVE,
+    /** No relevance scoring; ordered by sort or insertion. */
+    NONE
+}

--- a/src/main/java/ac/grim/grimac/api/storage/search/Scored.java
+++ b/src/main/java/ac/grim/grimac/api/storage/search/Scored.java
@@ -1,0 +1,13 @@
+package ac.grim.grimac.api.storage.search;
+
+import org.jetbrains.annotations.ApiStatus;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * A search hit with normalized + raw score. Normalized score is 0..1
+ * (1 = best in this result set); raw score is the backend's native
+ * value (BM25, ts_rank, textScore).
+ */
+@ApiStatus.Experimental
+public record Scored<R>(@NotNull R value, double normalizedScore, double rawScore) {
+}

--- a/src/main/java/ac/grim/grimac/api/storage/search/SearchResult.java
+++ b/src/main/java/ac/grim/grimac/api/storage/search/SearchResult.java
@@ -1,0 +1,29 @@
+package ac.grim.grimac.api.storage.search;
+
+import ac.grim.grimac.api.storage.query.Cursor;
+import org.jetbrains.annotations.ApiStatus;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Result of a {@link SearchSpec} execution. Hits carry both the
+ * deserialized record and its score; facets are keyed by request field;
+ * {@code nextCursor} is non-null when more pages exist.
+ */
+@ApiStatus.Experimental
+public record SearchResult<R>(
+        @NotNull List<Scored<R>> hits,
+        @NotNull Map<String, FacetResult> facets,
+        long totalEstimate,
+        @Nullable Cursor nextCursor) {
+
+    public SearchResult {
+        hits = List.copyOf(hits);
+        facets = Map.copyOf(facets);
+    }
+
+    public boolean hasMore() { return nextCursor != null; }
+}

--- a/src/main/java/ac/grim/grimac/api/storage/search/SearchSpec.java
+++ b/src/main/java/ac/grim/grimac/api/storage/search/SearchSpec.java
@@ -1,0 +1,85 @@
+package ac.grim.grimac.api.storage.search;
+
+import ac.grim.grimac.api.storage.query.Cursor;
+import org.jetbrains.annotations.ApiStatus;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Portable search query AST. Compiled to each backend's native FTS / vector
+ * primitives by its {@code SearchAdapter}. See
+ * {@code .docs/storage-redesign/04-search-tx-admin.md}.
+ */
+@ApiStatus.Experimental
+public record SearchSpec(
+        @NotNull List<Match> matches,
+        @NotNull List<Filter> filters,
+        @NotNull List<FacetRequest> facets,
+        @NotNull List<Sort> sort,
+        @Nullable VectorQuery vector,
+        @NotNull Rank rank,
+        int pageSize,
+        @Nullable Cursor cursor) {
+
+    public SearchSpec {
+        matches = List.copyOf(matches);
+        filters = List.copyOf(filters);
+        facets = List.copyOf(facets);
+        sort = List.copyOf(sort);
+    }
+
+    public record Match(@NotNull String field, @NotNull String query, @NotNull MatchMode mode, double boost) {}
+
+    public record Filter(@NotNull String field, @NotNull FilterOp op, @Nullable Object value) {}
+
+    public record FacetRequest(@NotNull String field, @NotNull FacetType type, @Nullable Object params) {}
+
+    public record Sort(@NotNull String field, @NotNull Direction direction) {}
+
+    public record VectorQuery(@NotNull String field, float @NotNull [] vector, int k) {}
+
+    public static @NotNull Builder builder() { return new Builder(); }
+
+    public static final class Builder {
+        private final List<Match> matches = new ArrayList<>();
+        private final List<Filter> filters = new ArrayList<>();
+        private final List<FacetRequest> facets = new ArrayList<>();
+        private final List<Sort> sort = new ArrayList<>();
+        private VectorQuery vector;
+        private Rank rank = Rank.BM25;
+        private int pageSize = 20;
+        private Cursor cursor;
+
+        public @NotNull Builder match(@NotNull String field, @NotNull String query, @NotNull MatchMode mode) {
+            return match(field, query, mode, 1.0);
+        }
+        public @NotNull Builder match(@NotNull String field, @NotNull String query, @NotNull MatchMode mode, double boost) {
+            matches.add(new Match(field, query, mode, boost)); return this;
+        }
+        public @NotNull Builder filter(@NotNull String field, @NotNull FilterOp op, @Nullable Object value) {
+            filters.add(new Filter(field, op, value)); return this;
+        }
+        public @NotNull Builder facet(@NotNull String field, @NotNull FacetType type) {
+            facets.add(new FacetRequest(field, type, null)); return this;
+        }
+        public @NotNull Builder facet(@NotNull String field, @NotNull FacetType type, @NotNull Object params) {
+            facets.add(new FacetRequest(field, type, params)); return this;
+        }
+        public @NotNull Builder sort(@NotNull String field, @NotNull Direction dir) {
+            sort.add(new Sort(field, dir)); return this;
+        }
+        public @NotNull Builder vector(@NotNull String field, float @NotNull [] v, int k) {
+            this.vector = new VectorQuery(field, v, k); return this;
+        }
+        public @NotNull Builder rank(@NotNull Rank r) { this.rank = r; return this; }
+        public @NotNull Builder pageSize(int n) { this.pageSize = n; return this; }
+        public @NotNull Builder cursor(@Nullable Cursor c) { this.cursor = c; return this; }
+
+        public @NotNull SearchSpec build() {
+            return new SearchSpec(matches, filters, facets, sort, vector, rank, pageSize, cursor);
+        }
+    }
+}

--- a/src/main/java/ac/grim/grimac/api/storage/tx/Transaction.java
+++ b/src/main/java/ac/grim/grimac/api/storage/tx/Transaction.java
@@ -1,0 +1,25 @@
+package ac.grim.grimac.api.storage.tx;
+
+import ac.grim.grimac.api.storage.category.Category;
+import ac.grim.grimac.api.storage.kind.Operation;
+import org.jetbrains.annotations.ApiStatus;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.function.Consumer;
+
+/**
+ * Inside-transaction handle passed to {@link TxBody#run}. All operations
+ * submitted or executed through this handle are part of the same atomic unit;
+ * SQL/Mongo wrap them in a real transaction, Redis compiles them to one Lua
+ * script.
+ */
+@ApiStatus.Experimental
+public interface Transaction {
+
+    <E> void submit(@NotNull Category<E> cat, @NotNull Consumer<E> configurer);
+
+    <R> R execute(@NotNull Operation<R> op) throws Exception;
+
+    /** Explicit rollback. Equivalent to throwing from the body. */
+    void rollback();
+}

--- a/src/main/java/ac/grim/grimac/api/storage/tx/TxBody.java
+++ b/src/main/java/ac/grim/grimac/api/storage/tx/TxBody.java
@@ -1,0 +1,14 @@
+package ac.grim.grimac.api.storage.tx;
+
+import org.jetbrains.annotations.ApiStatus;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * Function executed inside a {@link Transaction}. Throw to roll back; return
+ * to commit.
+ */
+@ApiStatus.Experimental
+@FunctionalInterface
+public interface TxBody<T> {
+    T run(@NotNull Transaction tx) throws Exception;
+}

--- a/src/main/java/ac/grim/grimac/api/storage/tx/TxScope.java
+++ b/src/main/java/ac/grim/grimac/api/storage/tx/TxScope.java
@@ -1,0 +1,34 @@
+package ac.grim.grimac.api.storage.tx;
+
+import org.jetbrains.annotations.ApiStatus;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.UUID;
+
+/**
+ * Co-location scope for a {@link Transaction}. Drives Redis hash-tag
+ * generation so all keys touched in the transaction hash to the same Redis
+ * Cluster slot. Ignored on SQL and Mongo, where transactions are slot-free.
+ * <p>
+ * Backends that advertise only {@code TX_LOCAL} require every transaction
+ * to declare a scope; only backends advertising {@code TX_GLOBAL} support
+ * scope-free transactions.
+ */
+@ApiStatus.Experimental
+public sealed interface TxScope {
+
+    /** Hash-tag string injected into Redis keys. */
+    @NotNull String tag();
+
+    record Player(@NotNull UUID uuid) implements TxScope {
+        @Override public @NotNull String tag() { return "player:" + uuid; }
+    }
+
+    record Server(@NotNull String name) implements TxScope {
+        @Override public @NotNull String tag() { return "server:" + name; }
+    }
+
+    record Custom(@NotNull String value) implements TxScope {
+        @Override public @NotNull String tag() { return value; }
+    }
+}


### PR DESCRIPTION
## Summary
- Create missing SQLite parent directories before opening V2 SQLite database files.
- Keep the optional SQLite driver-holder model with a clear init error when the JDBC driver is unavailable.
- Quote SQL KV identifiers for MySQL/MariaDB reserved words.
- Restore the planned optional V2 search/tx/admin adapter SPI placeholders.
- Add focused SQLite/KV regression coverage.

## Verification
- JAVA_HOME=/usr/lib/jvm/java-21-openjdk ./gradlew :grim-internal:test --tests ac.grim.grimac.internal.storage.core.V2RoutesBuilderTest --tests ac.grim.grimac.internal.storage.backend.sql.v2.SqlKeyValueScopedAdapterTest --tests ac.grim.grimac.internal.storage.backend.V2BackendIntegrationTest.sqlite