### PR TITLE
storage: support legacy SQLite v2 upserts

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,1 @@
-version = 1.6.0.1
+version = 1.6.0.2

--- a/grim-internal/src/main/java/ac/grim/grimac/internal/storage/backend/sql/v2/SqlCounterAdapter.java
+++ b/grim-internal/src/main/java/ac/grim/grimac/internal/storage/backend/sql/v2/SqlCounterAdapter.java
@@ -94,6 +94,9 @@ public final class SqlCounterAdapter implements KindAdapter<Counter<?>> {
             @NotNull StoreId id, @NotNull Counter<?> kind, @NotNull Category<E> category) {
         String table = dialect.quoteIdentifier(id.name());
         String upsertSql = dialect.counterIncrementSql(table);
+        if (dialect.usesLegacySqliteUpsert()) {
+            return new LegacyCounterWriteHandler<>(table);
+        }
         return new CounterWriteHandler<>(upsertSql);
     }
 
@@ -140,6 +143,37 @@ public final class SqlCounterAdapter implements KindAdapter<Counter<?>> {
         }
     }
 
+    private final class LegacyCounterWriteHandler<E> implements StorageEventHandler<E> {
+        private final String table;
+
+        LegacyCounterWriteHandler(String table) {
+            this.table = table;
+        }
+
+        @Override
+        public void onEvent(E event, long sequence, boolean endOfBatch) throws BackendException {
+            CounterEvent<?> ce = (CounterEvent<?>) event;
+            if (ce.key == null) return;
+            if (ce.delta == 0L) return;
+            try (Connection c = ds.getConnection()) {
+                boolean prior = c.getAutoCommit();
+                c.setAutoCommit(false);
+                try {
+                    legacyInsertCounter(c, table, ce.key, 0L);
+                    legacyAddCounter(c, table, ce.key, ce.delta);
+                    c.commit();
+                } catch (Exception e) {
+                    try { c.rollback(); } catch (SQLException ignored) {}
+                    throw e;
+                } finally {
+                    c.setAutoCommit(prior);
+                }
+            } catch (SQLException e) {
+                throw new BackendException("counter write failed", e);
+            }
+        }
+    }
+
     // ============================== execute dispatch ==============================
 
     private long get(@NotNull StoreId id, @NotNull CounterOps.GetOp<?> op) throws SQLException {
@@ -179,6 +213,9 @@ public final class SqlCounterAdapter implements KindAdapter<Counter<?>> {
 
     private long incrementBy(@NotNull StoreId id, @NotNull CounterOps.IncrementByOp<?> op) throws SQLException {
         String table = dialect.quoteIdentifier(id.name());
+        if (dialect.usesLegacySqliteUpsert()) {
+            return legacyIncrementBy(table, op.key(), op.delta());
+        }
         String upsert = dialect.counterIncrementSql(table);
         if (dialect.supportsReturning()) {
             String sql = upsert + " RETURNING value";
@@ -220,6 +257,9 @@ public final class SqlCounterAdapter implements KindAdapter<Counter<?>> {
 
     private long setIfHigher(@NotNull StoreId id, @NotNull CounterOps.SetIfHigherOp<?> op) throws SQLException {
         String table = dialect.quoteIdentifier(id.name());
+        if (dialect.usesLegacySqliteUpsert()) {
+            return legacySetIfHigher(table, op.key(), op.value());
+        }
         String valCol = dialect.quoteIdentifier("value");
         String greatest = dialect.greatestFn(table + "." + valCol, dialect.excludedRef(valCol));
         String upsert = dialect.counterIncrementSql(table)
@@ -274,6 +314,99 @@ public final class SqlCounterAdapter implements KindAdapter<Counter<?>> {
                 throw e;
             } finally {
                 c.setAutoCommit(prior);
+            }
+        }
+    }
+
+    private long legacyIncrementBy(@NotNull String table, @NotNull Object key, long delta) throws SQLException {
+        try (Connection c = ds.getConnection()) {
+            boolean prior = c.getAutoCommit();
+            c.setAutoCommit(false);
+            try {
+                legacyInsertCounter(c, table, key, 0L);
+                legacyAddCounter(c, table, key, delta);
+                long value = selectCounterValue(c, table, key, delta);
+                c.commit();
+                return value;
+            } catch (Exception e) {
+                try { c.rollback(); } catch (SQLException ignored) {}
+                throw e;
+            } finally {
+                c.setAutoCommit(prior);
+            }
+        }
+    }
+
+    private long legacySetIfHigher(@NotNull String table, @NotNull Object key, long value) throws SQLException {
+        try (Connection c = ds.getConnection()) {
+            boolean prior = c.getAutoCommit();
+            c.setAutoCommit(false);
+            try {
+                legacyInsertCounter(c, table, key, value);
+                legacyMaxCounter(c, table, key, value);
+                long current = selectCounterValue(c, table, key, value);
+                c.commit();
+                return current;
+            } catch (Exception e) {
+                try { c.rollback(); } catch (SQLException ignored) {}
+                throw e;
+            } finally {
+                c.setAutoCommit(prior);
+            }
+        }
+    }
+
+    private void legacyInsertCounter(
+            @NotNull Connection c,
+            @NotNull String table,
+            @NotNull Object key,
+            long value) throws SQLException {
+        try (PreparedStatement ps = c.prepareStatement("INSERT OR IGNORE INTO " + table
+                + " (" + dialect.quoteIdentifier("id") + ", " + dialect.quoteIdentifier("value") + ") VALUES (?, ?)")) {
+            bindKey(ps, 1, key);
+            ps.setLong(2, value);
+            ps.executeUpdate();
+        }
+    }
+
+    private void legacyAddCounter(
+            @NotNull Connection c,
+            @NotNull String table,
+            @NotNull Object key,
+            long delta) throws SQLException {
+        String value = dialect.quoteIdentifier("value");
+        try (PreparedStatement ps = c.prepareStatement("UPDATE " + table
+                + " SET " + value + " = " + value + " + ? WHERE " + dialect.quoteIdentifier("id") + " = ?")) {
+            ps.setLong(1, delta);
+            bindKey(ps, 2, key);
+            ps.executeUpdate();
+        }
+    }
+
+    private void legacyMaxCounter(
+            @NotNull Connection c,
+            @NotNull String table,
+            @NotNull Object key,
+            long incoming) throws SQLException {
+        String value = dialect.quoteIdentifier("value");
+        try (PreparedStatement ps = c.prepareStatement("UPDATE " + table
+                + " SET " + value + " = MAX(" + value + ", ?) WHERE " + dialect.quoteIdentifier("id") + " = ?")) {
+            ps.setLong(1, incoming);
+            bindKey(ps, 2, key);
+            ps.executeUpdate();
+        }
+    }
+
+    private long selectCounterValue(
+            @NotNull Connection c,
+            @NotNull String table,
+            @NotNull Object key,
+            long fallback) throws SQLException {
+        try (PreparedStatement ps = c.prepareStatement("SELECT value FROM " + table
+                + " WHERE " + dialect.quoteIdentifier("id") + " = ?")) {
+            bindKey(ps, 1, key);
+            try (ResultSet rs = ps.executeQuery()) {
+                return rs.next() ? rs.getLong("value") : fallback;
             }
         }
     }

--- a/grim-internal/src/main/java/ac/grim/grimac/internal/storage/backend/sql/v2/SqlEntityAdapter.java
+++ b/grim-internal/src/main/java/ac/grim/grimac/internal/storage/backend/sql/v2/SqlEntityAdapter.java
@@ -6,6 +6,7 @@ import ac.grim.grimac.api.storage.backend.StorageEventHandler;
 import ac.grim.grimac.api.storage.category.Capability;
 import ac.grim.grimac.api.storage.category.Category;
 import ac.grim.grimac.api.storage.codec.EncodeShape;
+import ac.grim.grimac.api.storage.codec.MergeMode;
 import ac.grim.grimac.api.storage.kind.Entity;
 import ac.grim.grimac.api.storage.kind.IndexSpec;
 import ac.grim.grimac.api.storage.kind.Operation;
@@ -241,6 +242,9 @@ public final class SqlEntityAdapter implements KindAdapter<Entity<?, ?, ?>> {
             @NotNull Category<E> category) {
         @SuppressWarnings("unchecked")
         Entity<?, E, ?> typed = (Entity<?, E, ?>) kind;
+        if (dialect.usesLegacySqliteUpsert()) {
+            return new LegacySqliteEntityHandler<>(id, typed);
+        }
         return new SqlEntityHandler<>(id, typed);
     }
 
@@ -292,6 +296,148 @@ public final class SqlEntityAdapter implements KindAdapter<Entity<?, ?, ?>> {
                 throw new BackendException("sql entity upsert failed for " + id, e);
             }
         }
+    }
+
+    /**
+     * Pre-3.24 SQLite cannot parse {@code ON CONFLICT DO UPDATE}. Use
+     * the same row semantics with a two-step transaction selected once
+     * at handler construction: {@code INSERT OR IGNORE}, then
+     * {@code UPDATE} with the same per-field merge expressions.
+     */
+    private final class LegacySqliteEntityHandler<E> implements StorageEventHandler<E> {
+
+        private final @NotNull StoreId id;
+        private final @NotNull String insertSql;
+        private final @Nullable String updateSql;
+        private final @NotNull List<Integer> updateIndexes;
+        @SuppressWarnings("rawtypes")
+        private final @NotNull BsonCodec codec;
+        private final @NotNull EncodeShape shape;
+        private final int idIndex;
+        private final @NotNull Function<E, Object> eventToRecord;
+
+        @SuppressWarnings({"unchecked", "rawtypes"})
+        LegacySqliteEntityHandler(@NotNull StoreId id, @NotNull Entity<?, E, ?> kind) {
+            this.id = id;
+            this.shape = kind.codec().shape();
+            this.insertSql = legacyInsertSql(id.name(), shape);
+            this.updateIndexes = legacyUpdateIndexes(shape);
+            this.updateSql = updateIndexes.isEmpty() ? null : legacyUpdateSql(id.name(), shape, updateIndexes);
+            this.idIndex = idFieldIndex(shape);
+            this.codec = BsonCodecs.regular(kind.recordType());
+            this.eventToRecord = (Function) kind.eventToRecord();
+        }
+
+        @Override
+        @SuppressWarnings({"unchecked", "rawtypes"})
+        public void onEvent(E event, long sequence, boolean endOfBatch) throws BackendException {
+            try {
+                Object record = eventToRecord.apply(event);
+                try (Connection c = ds.getConnection()) {
+                    boolean priorAutoCommit = c.getAutoCommit();
+                    c.setAutoCommit(false);
+                    try {
+                        try (PreparedStatement insert = c.prepareStatement(insertSql)) {
+                            bindAllFields(insert, record);
+                            insert.executeUpdate();
+                        }
+                        if (updateSql != null) {
+                            try (PreparedStatement update = c.prepareStatement(updateSql)) {
+                                int param = 1;
+                                for (int fieldIndex : updateIndexes) {
+                                    EncodeShape.FieldDef f = shape.fields().get(fieldIndex);
+                                    SqlBindings.bind(update, param++, f, codec.readField(record, fieldIndex));
+                                }
+                                EncodeShape.FieldDef idField = shape.fields().get(idIndex);
+                                SqlBindings.bind(update, param, idField, codec.readField(record, idIndex));
+                                update.executeUpdate();
+                            }
+                        }
+                        c.commit();
+                    } catch (Exception e) {
+                        try { c.rollback(); } catch (SQLException ignored) {}
+                        throw e;
+                    } finally {
+                        c.setAutoCommit(priorAutoCommit);
+                    }
+                }
+            } catch (SQLException | RuntimeException e) {
+                throw new BackendException("sql entity upsert failed for " + id, e);
+            }
+        }
+
+        private void bindAllFields(@NotNull PreparedStatement ps, @NotNull Object record)
+                throws SQLException {
+            int n = shape.fields().size();
+            for (int i = 0; i < n; i++) {
+                EncodeShape.FieldDef f = shape.fields().get(i);
+                SqlBindings.bind(ps, i + 1, f, codec.readField(record, i));
+            }
+        }
+    }
+
+    private @NotNull String legacyInsertSql(@NotNull String tableName, @NotNull EncodeShape shape) {
+        StringBuilder sb = new StringBuilder();
+        sb.append("INSERT OR IGNORE INTO ").append(dialect.quoteIdentifier(tableName)).append(" (");
+        boolean first = true;
+        for (EncodeShape.FieldDef f : shape.fields()) {
+            if (!first) sb.append(", ");
+            sb.append(dialect.quoteIdentifier(f.name()));
+            first = false;
+        }
+        sb.append(") VALUES (");
+        for (int i = 0; i < shape.fields().size(); i++) {
+            if (i > 0) sb.append(", ");
+            sb.append('?');
+        }
+        sb.append(')');
+        return sb.toString();
+    }
+
+    private @NotNull List<Integer> legacyUpdateIndexes(@NotNull EncodeShape shape) {
+        List<Integer> indexes = new ArrayList<>();
+        for (int i = 0; i < shape.fields().size(); i++) {
+            EncodeShape.FieldDef f = shape.fields().get(i);
+            if (f.name().equals(shape.idField())) continue;
+            if (f.mergeMode() == MergeMode.INSERT_ONLY) continue;
+            indexes.add(i);
+        }
+        return indexes;
+    }
+
+    private @NotNull String legacyUpdateSql(
+            @NotNull String tableName,
+            @NotNull EncodeShape shape,
+            @NotNull List<Integer> updateIndexes) {
+        StringBuilder sb = new StringBuilder();
+        sb.append("UPDATE ").append(dialect.quoteIdentifier(tableName)).append(" SET ");
+        boolean first = true;
+        for (int index : updateIndexes) {
+            if (!first) sb.append(", ");
+            EncodeShape.FieldDef f = shape.fields().get(index);
+            String col = dialect.quoteIdentifier(f.name());
+            sb.append(col).append(" = ");
+            switch (f.mergeMode()) {
+                case OVERWRITE -> sb.append('?');
+                case PRESERVE_ON_NON_NULL -> sb.append("COALESCE(").append(col).append(", ?)");
+                case PRESERVE_ON_NON_SENTINEL -> sb.append("CASE WHEN ")
+                    .append(col).append(" IS NULL OR ").append(col).append(" = ")
+                    .append(f.sentinelValue()).append(" THEN ? ELSE ").append(col).append(" END");
+                case MAX -> sb.append("MAX(").append(col).append(", ?)");
+                case MIN -> sb.append("MIN(").append(col).append(", ?)");
+                case INSERT_ONLY -> { /* excluded above */ }
+            }
+            first = false;
+        }
+        sb.append(" WHERE ").append(dialect.quoteIdentifier(shape.idField())).append(" = ?");
+        return sb.toString();
+    }
+
+    private static int idFieldIndex(@NotNull EncodeShape shape) {
+        for (int i = 0; i < shape.fields().size(); i++) {
+            if (shape.fields().get(i).name().equals(shape.idField())) return i;
+        }
+        throw new IllegalArgumentException("EncodeShape id field missing: " + shape.idField());
     }
 
     @SuppressWarnings({"unchecked", "rawtypes"})

--- a/grim-internal/src/main/java/ac/grim/grimac/internal/storage/backend/sql/v2/SqlKeyValueScopedAdapter.java
+++ b/grim-internal/src/main/java/ac/grim/grimac/internal/storage/backend/sql/v2/SqlKeyValueScopedAdapter.java
@@ -105,6 +105,9 @@ public final class SqlKeyValueScopedAdapter implements KindAdapter<KeyValueScope
             + " WHERE " + dialect.quoteIdentifier("scope") + " = ?"
             + " AND " + dialect.quoteIdentifier("scope_key") + " = ?"
             + " AND " + dialect.quoteIdentifier("key") + " = ?";
+        if (dialect.usesLegacySqliteUpsert()) {
+            return new LegacyKVWriteHandler<>(legacyKvInsertSql(table), legacyKvUpdateSql(table), deleteSql);
+        }
         return new KVWriteHandler<>(upsertSql, deleteSql);
     }
 
@@ -173,6 +176,52 @@ public final class SqlKeyValueScopedAdapter implements KindAdapter<KeyValueScope
         }
     }
 
+    private final class LegacyKVWriteHandler<E> implements StorageEventHandler<E> {
+        private final String insertSql;
+        private final String updateSql;
+        private final String deleteSql;
+
+        LegacyKVWriteHandler(String insertSql, String updateSql, String deleteSql) {
+            this.insertSql = insertSql;
+            this.updateSql = updateSql;
+            this.deleteSql = deleteSql;
+        }
+
+        @Override
+        public void onEvent(E event, long sequence, boolean endOfBatch) throws BackendException {
+            KeyValueEvent<?, ?> kve = (KeyValueEvent<?, ?>) event;
+            if (kve.scope == null || kve.scopeKey == null || kve.key == null) return;
+            try (Connection c = ds.getConnection()) {
+                if (kve.remove) {
+                    try (PreparedStatement ps = c.prepareStatement(deleteSql)) {
+                        ps.setString(1, String.valueOf(kve.scope));
+                        ps.setString(2, String.valueOf(kve.scopeKey));
+                        ps.setString(3, kve.key);
+                        ps.executeUpdate();
+                    }
+                    return;
+                }
+                if (kve.value == null) {
+                    throw new BackendException("KV PutOp value must be non-null; use remove flag for deletion");
+                }
+                boolean priorAutoCommit = c.getAutoCommit();
+                c.setAutoCommit(false);
+                try {
+                    legacyKvUpsert(c, insertSql, updateSql, String.valueOf(kve.scope),
+                        String.valueOf(kve.scopeKey), kve.key, valueAsBytes(kve.value), kve.updatedEpochMs);
+                    c.commit();
+                } catch (Exception e) {
+                    try { c.rollback(); } catch (SQLException ignored) {}
+                    throw e;
+                } finally {
+                    c.setAutoCommit(priorAutoCommit);
+                }
+            } catch (SQLException e) {
+                throw new BackendException("kv write failed", e);
+            }
+        }
+    }
+
     /**
      * Coerce a KV slot's value to bytes for {@code setBytes}. byte[]
      * passes through; String falls back to UTF-8 so legacy callers
@@ -186,6 +235,53 @@ public final class SqlKeyValueScopedAdapter implements KindAdapter<KeyValueScope
         if (value instanceof String s)
             return s.getBytes(java.nio.charset.StandardCharsets.UTF_8);
         throw new BackendException("KV value must be byte[] or String, got " + value.getClass().getName());
+    }
+
+    private @NotNull String legacyKvInsertSql(@NotNull String table) {
+        String scope = dialect.quoteIdentifier("scope");
+        String scopeKey = dialect.quoteIdentifier("scope_key");
+        String key = dialect.quoteIdentifier("key");
+        String value = dialect.quoteIdentifier("value");
+        String updatedAt = dialect.quoteIdentifier("updated_at");
+        return "INSERT OR IGNORE INTO " + table + " (" + scope + ", " + scopeKey + ", " + key
+            + ", " + value + ", " + updatedAt + ") VALUES (?, ?, ?, ?, ?)";
+    }
+
+    private @NotNull String legacyKvUpdateSql(@NotNull String table) {
+        String scope = dialect.quoteIdentifier("scope");
+        String scopeKey = dialect.quoteIdentifier("scope_key");
+        String key = dialect.quoteIdentifier("key");
+        String value = dialect.quoteIdentifier("value");
+        String updatedAt = dialect.quoteIdentifier("updated_at");
+        return "UPDATE " + table + " SET " + value + " = ?, " + updatedAt + " = ?"
+            + " WHERE " + scope + " = ? AND " + scopeKey + " = ? AND " + key + " = ?";
+    }
+
+    private void legacyKvUpsert(
+            @NotNull Connection c,
+            @NotNull String insertSql,
+            @NotNull String updateSql,
+            @NotNull String scope,
+            @NotNull String scopeKey,
+            @NotNull String key,
+            byte @NotNull [] value,
+            long updatedAt) throws SQLException {
+        try (PreparedStatement insert = c.prepareStatement(insertSql)) {
+            insert.setString(1, scope);
+            insert.setString(2, scopeKey);
+            insert.setString(3, key);
+            insert.setBytes(4, value);
+            insert.setLong(5, updatedAt);
+            insert.executeUpdate();
+        }
+        try (PreparedStatement update = c.prepareStatement(updateSql)) {
+            update.setBytes(1, value);
+            update.setLong(2, updatedAt);
+            update.setString(3, scope);
+            update.setString(4, scopeKey);
+            update.setString(5, key);
+            update.executeUpdate();
+        }
     }
 
     // ============================== execute dispatch ==============================
@@ -236,6 +332,24 @@ public final class SqlKeyValueScopedAdapter implements KindAdapter<KeyValueScope
             throw new IllegalArgumentException("KV PutOp value must be non-null; use RemoveOp for deletion");
         }
         String table = dialect.quoteIdentifier(id.name());
+        if (dialect.usesLegacySqliteUpsert()) {
+            try (Connection c = ds.getConnection()) {
+                boolean prior = c.getAutoCommit();
+                c.setAutoCommit(false);
+                try {
+                    legacyKvUpsert(c, legacyKvInsertSql(table), legacyKvUpdateSql(table),
+                        String.valueOf(op.scope()), op.scopeKey(), op.key(),
+                        valueAsBytes(op.value()), System.currentTimeMillis());
+                    c.commit();
+                } catch (Exception e) {
+                    try { c.rollback(); } catch (SQLException ignored) {}
+                    throw e;
+                } finally {
+                    c.setAutoCommit(prior);
+                }
+            }
+            return;
+        }
         String sql = dialect.kvUpsertSql(table);
         try (Connection c = ds.getConnection(); PreparedStatement ps = c.prepareStatement(sql)) {
             ps.setString(1, String.valueOf(op.scope()));
@@ -250,23 +364,37 @@ public final class SqlKeyValueScopedAdapter implements KindAdapter<KeyValueScope
     private void putAll(@NotNull StoreId id, @NotNull KeyValueScopedOps.PutAllOp<?, ?> op) throws SQLException, BackendException {
         String table = dialect.quoteIdentifier(id.name());
         String sql = dialect.kvUpsertSql(table);
+        String legacyInsert = legacyKvInsertSql(table);
+        String legacyUpdate = legacyKvUpdateSql(table);
         long now = System.currentTimeMillis();
         try (Connection c = ds.getConnection()) {
             boolean priorAutoCommit = c.getAutoCommit();
             c.setAutoCommit(false);
-            try (PreparedStatement ps = c.prepareStatement(sql)) {
-                for (Map.Entry<String, ?> e : op.values().entrySet()) {
-                    if (e.getValue() == null) {
-                        throw new IllegalArgumentException("KV PutAllOp value for key '" + e.getKey() + "' must be non-null");
+            try {
+                if (dialect.usesLegacySqliteUpsert()) {
+                    for (Map.Entry<String, ?> e : op.values().entrySet()) {
+                        if (e.getValue() == null) {
+                            throw new IllegalArgumentException("KV PutAllOp value for key '" + e.getKey() + "' must be non-null");
+                        }
+                        legacyKvUpsert(c, legacyInsert, legacyUpdate, String.valueOf(op.scope()),
+                            op.scopeKey(), e.getKey(), valueAsBytes(e.getValue()), now);
                     }
-                    ps.setString(1, String.valueOf(op.scope()));
-                    ps.setString(2, op.scopeKey());
-                    ps.setString(3, e.getKey());
-                    ps.setBytes(4, valueAsBytes(e.getValue()));
-                    ps.setLong(5, now);
-                    ps.addBatch();
+                } else {
+                    try (PreparedStatement ps = c.prepareStatement(sql)) {
+                        for (Map.Entry<String, ?> e : op.values().entrySet()) {
+                            if (e.getValue() == null) {
+                                throw new IllegalArgumentException("KV PutAllOp value for key '" + e.getKey() + "' must be non-null");
+                            }
+                            ps.setString(1, String.valueOf(op.scope()));
+                            ps.setString(2, op.scopeKey());
+                            ps.setString(3, e.getKey());
+                            ps.setBytes(4, valueAsBytes(e.getValue()));
+                            ps.setLong(5, now);
+                            ps.addBatch();
+                        }
+                        ps.executeBatch();
+                    }
                 }
-                ps.executeBatch();
                 c.commit();
             } catch (Exception e) {
                 try { c.rollback(); } catch (SQLException ignored) {}

--- a/grim-internal/src/main/java/ac/grim/grimac/internal/storage/backend/sql/v2/dialect/SqlDialect.java
+++ b/grim-internal/src/main/java/ac/grim/grimac/internal/storage/backend/sql/v2/dialect/SqlDialect.java
@@ -108,6 +108,13 @@ public interface SqlDialect {
     @NotNull String upsertSql(@NotNull String tableName, @NotNull EncodeShape shape);
 
     /**
+     * True when SQLite must avoid modern UPSERT / RETURNING syntax.
+     * SQLite engines before 3.24 reject {@code ON CONFLICT DO UPDATE},
+     * which is still common on old Bukkit-family servers.
+     */
+    default boolean usesLegacySqliteUpsert() { return false; }
+
+    /**
      * Whether this dialect supports {@code RETURNING <columns>} on
      * INSERT/UPDATE. Postgres and SQLite 3.35+ do; MySQL does not.
      * When false, adapters that need post-write values (e.g. counter

--- a/grim-internal/src/main/java/ac/grim/grimac/internal/storage/backend/sql/v2/dialect/SqliteDialect.java
+++ b/grim-internal/src/main/java/ac/grim/grimac/internal/storage/backend/sql/v2/dialect/SqliteDialect.java
@@ -20,6 +20,29 @@ import java.util.UUID;
 @ApiStatus.Internal
 public final class SqliteDialect implements SqlDialect {
 
+    private final boolean legacyUpsert;
+    private final boolean supportsReturning;
+
+    public SqliteDialect() {
+        this(false, true);
+    }
+
+    private SqliteDialect(boolean legacyUpsert, boolean supportsReturning) {
+        this.legacyUpsert = legacyUpsert;
+        this.supportsReturning = supportsReturning;
+    }
+
+    @ApiStatus.Internal
+    public static @NotNull SqliteDialect legacyForTest() {
+        return new SqliteDialect(true, false);
+    }
+
+    public static @NotNull SqliteDialect forEngineVersion(@NotNull String version) {
+        boolean legacy = compareVersionTriple(version, 3, 24, 0) < 0;
+        boolean returning = compareVersionTriple(version, 3, 35, 0) >= 0;
+        return new SqliteDialect(legacy, returning);
+    }
+
     @Override public @NotNull String name() { return "sqlite"; }
 
     @Override
@@ -128,7 +151,9 @@ public final class SqliteDialect implements SqlDialect {
         return sb.toString();
     }
 
-    @Override public boolean supportsReturning() { return true; }
+    @Override public boolean usesLegacySqliteUpsert() { return legacyUpsert; }
+
+    @Override public boolean supportsReturning() { return supportsReturning; }
 
     @Override public @NotNull String greatestFn(@NotNull String a, @NotNull String b) {
         return "MAX(" + a + ", " + b + ")";
@@ -136,5 +161,22 @@ public final class SqliteDialect implements SqlDialect {
 
     private static @NotNull String q(@NotNull String name) {
         return PostgresDialect.quoteId(name); // same double-quote convention
+    }
+
+    private static int compareVersionTriple(String version, int majorFloor, int minorFloor, int patchFloor) {
+        int[] triple = {0, 0, 0};
+        int idx = 0;
+        int i = 0;
+        while (i < version.length() && idx < 3) {
+            int start = i;
+            while (i < version.length() && Character.isDigit(version.charAt(i))) i++;
+            if (i == start) break;
+            triple[idx++] = Integer.parseInt(version.substring(start, i));
+            if (i < version.length() && version.charAt(i) == '.') i++;
+            else break;
+        }
+        if (triple[0] != majorFloor) return Integer.compare(triple[0], majorFloor);
+        if (triple[1] != minorFloor) return Integer.compare(triple[1], minorFloor);
+        return Integer.compare(triple[2], patchFloor);
     }
 }

--- a/grim-internal/src/main/java/ac/grim/grimac/internal/storage/backend/sqlite/v2/SqliteBackendV2.java
+++ b/grim-internal/src/main/java/ac/grim/grimac/internal/storage/backend/sqlite/v2/SqliteBackendV2.java
@@ -40,7 +40,8 @@ import java.util.logging.Logger;
 public final class SqliteBackendV2 implements BackendV2 {
 
     private final @NotNull SqliteBackendConfig config;
-    private final @NotNull SqliteDialect dialect = new SqliteDialect();
+    private final SqliteDialect dialectOverride;
+    private SqliteDialect dialect;
     private Logger logger;
     private Connection connection;
     private javax.sql.DataSource singleConnDs;
@@ -50,7 +51,13 @@ public final class SqliteBackendV2 implements BackendV2 {
     private ac.grim.grimac.internal.storage.backend.sql.v2.SqlCounterAdapter counterAdapter;
 
     public SqliteBackendV2(@NotNull SqliteBackendConfig config) {
+        this(config, null);
+    }
+
+    @ApiStatus.Internal
+    public SqliteBackendV2(@NotNull SqliteBackendConfig config, SqliteDialect dialectOverride) {
         this.config = config;
+        this.dialectOverride = dialectOverride;
     }
 
     @Override public @NotNull String id() { return "sqlite-v2"; }
@@ -98,6 +105,7 @@ public final class SqliteBackendV2 implements BackendV2 {
             try (Statement s = connection.createStatement()) {
                 s.execute("PRAGMA busy_timeout=30000");
             }
+            this.dialect = dialectOverride != null ? dialectOverride : selectDialect(connection, logger);
         } catch (SQLException e) {
             throw new BackendException("failed to open SQLite database " + dbFile, e);
         }
@@ -106,6 +114,27 @@ public final class SqliteBackendV2 implements BackendV2 {
         this.eventStreamAdapter = new ac.grim.grimac.internal.storage.backend.sql.v2.SqlEventStreamAdapter(singleConnDs, dialect, logger);
         this.kvScopedAdapter = new ac.grim.grimac.internal.storage.backend.sql.v2.SqlKeyValueScopedAdapter(singleConnDs, dialect, logger);
         this.counterAdapter = new ac.grim.grimac.internal.storage.backend.sql.v2.SqlCounterAdapter(singleConnDs, dialect, logger);
+    }
+
+    private static @NotNull SqliteDialect selectDialect(
+            @NotNull Connection connection,
+            @NotNull Logger logger) throws SQLException {
+        String version;
+        try (Statement s = connection.createStatement();
+             java.sql.ResultSet rs = s.executeQuery("SELECT sqlite_version()")) {
+            if (!rs.next()) {
+                logger.warning("[grim-datastore] sqlite_version() returned no row; assuming modern SQLite dialect");
+                return new SqliteDialect();
+            }
+            version = rs.getString(1);
+        }
+        SqliteDialect selected = SqliteDialect.forEngineVersion(version);
+        logger.info("[grim-datastore] SQLite engine " + version + " — using "
+                + (selected.usesLegacySqliteUpsert()
+                ? "legacy (pre-3.24, no UPSERT) dialect"
+                : "modern dialect")
+                + (selected.supportsReturning() ? "" : " without RETURNING"));
+        return selected;
     }
 
     @Override public void flush() {}

--- a/grim-internal/src/test/java/ac/grim/grimac/internal/storage/backend/V2BackendIntegrationTest.java
+++ b/grim-internal/src/test/java/ac/grim/grimac/internal/storage/backend/V2BackendIntegrationTest.java
@@ -5,12 +5,17 @@ import ac.grim.grimac.api.storage.backend.BackendContext;
 import ac.grim.grimac.api.storage.backend.BackendV2;
 import ac.grim.grimac.api.storage.backend.KindAdapter;
 import ac.grim.grimac.api.storage.category.Categories;
+import ac.grim.grimac.api.storage.codec.Codec;
+import ac.grim.grimac.api.storage.codec.EncodeShape;
 import ac.grim.grimac.api.storage.config.TableNames;
 import ac.grim.grimac.api.storage.event.SettingEvent;
 import ac.grim.grimac.api.storage.event.ServerStartupEvent;
 import ac.grim.grimac.api.storage.event.SessionEvent;
+import ac.grim.grimac.api.storage.kind.Counter;
+import ac.grim.grimac.api.storage.kind.CounterEvent;
 import ac.grim.grimac.api.storage.kind.Entity;
 import ac.grim.grimac.api.storage.kind.KeyValueScoped;
+import ac.grim.grimac.api.storage.kind.ops.CounterOps;
 import ac.grim.grimac.api.storage.kind.ops.EntityOps;
 import ac.grim.grimac.api.storage.kind.ops.KeyValueScopedOps;
 import ac.grim.grimac.api.storage.model.PlayerIdentity;
@@ -26,6 +31,7 @@ import ac.grim.grimac.internal.storage.backend.redis.RedisBackendConfig;
 import ac.grim.grimac.internal.storage.backend.redis.v2.RedisBackendV2;
 import ac.grim.grimac.internal.storage.backend.sqlite.SqliteBackendConfig;
 import ac.grim.grimac.internal.storage.backend.sqlite.v2.SqliteBackendV2;
+import ac.grim.grimac.internal.storage.backend.sql.v2.dialect.SqliteDialect;
 import ac.grim.grimac.internal.storage.category.V2BuiltinKinds;
 import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.DisplayName;
@@ -62,6 +68,22 @@ class V2BackendIntegrationTest {
             exerciseEntityIndexes(backend, "v2_integ_players_sqlite", "v2_integ_sessions_sqlite",
                     "v2_integ_startups_sqlite");
             exerciseSettingsKv(backend, "v2_integ_settings_sqlite");
+            exerciseCounter(backend, "v2_integ_counters_sqlite");
+        } finally {
+            backend.close();
+        }
+    }
+
+    @Test @DisplayName("SQLite v2 legacy dialect: entity/KV/counter writes")
+    void sqliteLegacy(@TempDir Path tempDir) throws Exception {
+        SqliteBackendConfig cfg = SqliteBackendConfig.defaults("data/v2-legacy-integ.db");
+        SqliteBackendV2 backend = new SqliteBackendV2(cfg, SqliteDialect.legacyForTest());
+        try {
+            backend.init(ctx(cfg, tempDir));
+            exerciseEntityIndexes(backend, "v2_legacy_players_sqlite", "v2_legacy_sessions_sqlite",
+                    "v2_legacy_startups_sqlite");
+            exerciseSettingsKv(backend, "v2_legacy_settings_sqlite");
+            exerciseCounter(backend, "v2_legacy_counters_sqlite");
         } finally {
             backend.close();
         }
@@ -290,6 +312,37 @@ class V2BackendIntegrationTest {
         assertArrayEquals(new byte[]{1}, got.get(), backend.id() + ": setting KV value round-trips");
     }
 
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    private void exerciseCounter(BackendV2 backend, String counterStoreName) throws Exception {
+        StoreId counterStore = StoreId.grim(counterStoreName + "_" + Long.toHexString(System.nanoTime()));
+        Counter<String> counterKind = Counter.<String>builder()
+            .name("test-counter")
+            .key(String.class, STRING_CODEC)
+            .build();
+        KindAdapter adapter = backend.adapterFor(counterKind).orElseThrow(
+            () -> new AssertionError(backend.id() + " has no Counter adapter"));
+
+        adapter.ensureStore(counterStore, counterKind);
+
+        var handler = adapter.writeHandler(counterStore, counterKind, (ac.grim.grimac.api.storage.category.Category) Categories.SETTING);
+        CounterEvent<String> event = new CounterEvent<>();
+        event.key = "flags";
+        event.delta = 2L;
+        handler.onEvent(event, 0, true);
+
+        long afterIncrement = (Long) adapter.execute(counterStore, counterKind,
+            new CounterOps.IncrementByOp<>(Categories.SETTING, "flags", 3L));
+        assertEquals(5L, afterIncrement, backend.id() + ": counter increment merges");
+
+        long afterLowerSet = (Long) adapter.execute(counterStore, counterKind,
+            new CounterOps.SetIfHigherOp<>(Categories.SETTING, "flags", 4L));
+        assertEquals(5L, afterLowerSet, backend.id() + ": counter setIfHigher preserves higher value");
+
+        long afterHigherSet = (Long) adapter.execute(counterStore, counterKind,
+            new CounterOps.SetIfHigherOp<>(Categories.SETTING, "flags", 9L));
+        assertEquals(9L, afterHigherSet, backend.id() + ": counter setIfHigher raises value");
+    }
+
     private static void writeSession(ac.grim.grimac.api.storage.backend.StorageEventHandler<SessionEvent> handler,
                                      UUID sessionId, UUID playerId, UUID startupId, long started, long sequence) throws Exception {
         writeSession(handler, sessionId, playerId, startupId, started, SessionRecord.OPEN, sequence);
@@ -340,6 +393,13 @@ class V2BackendIntegrationTest {
             @Override public BackendConfig config() { return cfg; }
         };
     }
+
+    private static final Codec<String> STRING_CODEC = new Codec<>() {
+        @Override public Class<String> recordType() { return String.class; }
+        @Override public EncodeShape shape() { throw new UnsupportedOperationException("counter key only"); }
+        @Override public int version() { return 1; }
+        @Override public Object indexField(String record, String fieldName) { return null; }
+    };
 
     private static void assumeReachable(String host, int port) {
         try (Socket s = new Socket(host, port)) {


### PR DESCRIPTION
Fixes v2 SQLite startup on old Bukkit-family servers whose bundled SQLite engine predates UPSERT support.\n\nChanges:\n- Probe sqlite_version() in SqliteBackendV2 and select legacy mode below 3.24.\n- Use INSERT OR IGNORE + UPDATE handlers for v2 entity, KV, and counter writes on legacy SQLite.\n- Treat SQLite RETURNING as available only on 3.35+.\n- Add forced legacy SQLite v2 integration coverage.\n\nVerified:\n- JAVA_HOME=/usr/lib/jvm/java-21-openjdk ./gradlew :grim-internal:test --tests ac.grim.grimac.internal.storage.backend.V2BackendIntegrationTest.sqlite --tests ac.grim.grimac.internal.storage.backend.V2BackendIntegrationTest.sqliteLegacy\n- Deployed a Grim 2.0 test jar to pandaspigot-1.8.8; log shows SQLite engine 3.7.2 using legacy dialect and storage startup claimed without SQLITE_ERROR.