### PR TITLE
storage: allocate JDBC check ids explicitly

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,1 @@
-version = 1.6.0.2
+version = 1.6.0.3

--- a/grim-internal/src/main/java/ac/grim/grimac/internal/storage/checks/JdbcCheckCatalogPersistence.java
+++ b/grim-internal/src/main/java/ac/grim/grimac/internal/storage/checks/JdbcCheckCatalogPersistence.java
@@ -69,26 +69,47 @@ public final class JdbcCheckCatalogPersistence implements CheckCatalogPersistenc
                       @Nullable String description,
                       @Nullable String introducedVersion,
                       long introducedAt) {
-        try (Connection c = connections.open();
-             PreparedStatement ps = c.prepareStatement(
-                     "INSERT INTO " + checksTable + "(stable_key, display, description, introduced_version, introduced_at) "
-                             + "VALUES (?, ?, ?, ?, ?)",
-                     Statement.RETURN_GENERATED_KEYS)) {
-            ps.setString(1, stableKey);
-            bindNullableString(ps, 2, display);
-            bindNullableString(ps, 3, description);
-            bindNullableString(ps, 4, introducedVersion);
-            ps.setLong(5, introducedAt);
-            ps.executeUpdate();
-            try (ResultSet keys = ps.getGeneratedKeys()) {
-                if (keys.next()) return keys.getInt(1);
-                throw new SQLException("no generated key for " + checksTable + " insert");
+        SQLException lastFailure = null;
+        for (int attempt = 0; attempt < 5; attempt++) {
+            try (Connection c = connections.open()) {
+                boolean priorAutoCommit = c.getAutoCommit();
+                c.setAutoCommit(false);
+                try {
+                    Integer existing = findExistingId(c, stableKey);
+                    if (existing != null) {
+                        c.commit();
+                        return existing;
+                    }
+
+                    int checkId = nextCheckId(c);
+                    try (PreparedStatement ps = c.prepareStatement(
+                            "INSERT INTO " + checksTable
+                                    + "(check_id, stable_key, display, description, introduced_version, introduced_at) "
+                                    + "VALUES (?, ?, ?, ?, ?, ?)")) {
+                        ps.setInt(1, checkId);
+                        ps.setString(2, stableKey);
+                        bindNullableString(ps, 3, display);
+                        bindNullableString(ps, 4, description);
+                        bindNullableString(ps, 5, introducedVersion);
+                        ps.setLong(6, introducedAt);
+                        ps.executeUpdate();
+                    }
+                    alignSequence(c);
+                    c.commit();
+                    return checkId;
+                } catch (SQLException e) {
+                    lastFailure = e;
+                    try { c.rollback(); } catch (SQLException ignored) {}
+                    Integer existing = findExistingId(stableKey);
+                    if (existing != null) return existing;
+                } finally {
+                    try { c.setAutoCommit(priorAutoCommit); } catch (SQLException ignored) {}
+                }
+            } catch (SQLException e) {
+                lastFailure = e;
             }
-        } catch (SQLException e) {
-            Integer existing = findExistingId(stableKey);
-            if (existing != null) return existing;
-            throw new RuntimeException("failed to insert " + checksTable + " row for " + stableKey, e);
         }
+        throw new RuntimeException("failed to insert " + checksTable + " row for " + stableKey, lastFailure);
     }
 
     @Override
@@ -162,6 +183,26 @@ public final class JdbcCheckCatalogPersistence implements CheckCatalogPersistenc
         } catch (SQLException ignore) {
         }
         return null;
+    }
+
+    private Integer findExistingId(Connection c, String stableKey) throws SQLException {
+        try (PreparedStatement ps = c.prepareStatement(
+                "SELECT check_id FROM " + checksTable + " WHERE stable_key = ?")) {
+            ps.setString(1, stableKey);
+            try (ResultSet rs = ps.executeQuery()) {
+                if (rs.next()) return rs.getInt(1);
+            }
+        }
+        return null;
+    }
+
+    private int nextCheckId(Connection c) throws SQLException {
+        try (PreparedStatement ps = c.prepareStatement(
+                "SELECT COALESCE(MAX(check_id), 0) + 1 FROM " + checksTable);
+             ResultSet rs = ps.executeQuery()) {
+            if (rs.next()) return rs.getInt(1);
+        }
+        return 1;
     }
 
     private String findStableKeyById(int checkId) {

--- a/grim-internal/src/test/java/ac/grim/grimac/internal/storage/checks/JdbcCheckCatalogPersistenceTest.java
+++ b/grim-internal/src/test/java/ac/grim/grimac/internal/storage/checks/JdbcCheckCatalogPersistenceTest.java
@@ -1,0 +1,51 @@
+package ac.grim.grimac.internal.storage.checks;
+
+import ac.grim.grimac.api.storage.check.CheckCatalogRow;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.nio.file.Path;
+import java.sql.DriverManager;
+import java.sql.Statement;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class JdbcCheckCatalogPersistenceTest {
+
+    @Test
+    void insertAllocatesCheckIdsForV2SqlEntityShape(@TempDir Path tempDir) throws Exception {
+        String url = "jdbc:sqlite:" + tempDir.resolve("checks.db").toAbsolutePath();
+        try (var c = DriverManager.getConnection(url); Statement s = c.createStatement()) {
+            s.executeUpdate("""
+                CREATE TABLE grim_checks (
+                    stable_key TEXT PRIMARY KEY,
+                    check_id INTEGER NOT NULL,
+                    display TEXT,
+                    description TEXT,
+                    introduced_version TEXT,
+                    introduced_at INTEGER NOT NULL
+                )
+                """);
+            s.executeUpdate("CREATE UNIQUE INDEX grim_checks_by_check_id ON grim_checks (check_id)");
+        }
+
+        JdbcCheckCatalogPersistence checks = new JdbcCheckCatalogPersistence(
+            () -> DriverManager.getConnection(url), "grim_checks");
+
+        assertEquals(1, checks.insert("movement.simulation", "Simulation", "desc", "2.3.75", 10L));
+        assertEquals(2, checks.insert("combat.reach", "Reach", null, "2.3.75", 20L));
+        assertEquals(1, checks.insert("movement.simulation", "Simulation", "desc", "2.3.75", 10L));
+
+        List<CheckCatalogRow> rows = new ArrayList<>();
+        checks.loadAll().forEach(rows::add);
+        Map<Integer, String> stableKeysById = rows.stream()
+            .collect(Collectors.toMap(CheckCatalogRow::checkId, CheckCatalogRow::stableKey));
+        assertEquals(2, rows.size());
+        assertEquals("movement.simulation", stableKeysById.get(1));
+        assertEquals("combat.reach", stableKeysById.get(2));
+    }
+}


### PR DESCRIPTION
## Summary\n- allocate check catalog ids explicitly for JDBC backends instead of relying on generated keys\n- supports the v2 SQL entity-shaped grim_checks table where stable_key is the primary key and check_id is a unique value column\n- bump API version to 1.6.0.3\n\n## Tests\n- JAVA_HOME=/usr/lib/jvm/java-21-openjdk ./gradlew :grim-internal:test --tests ac.grim.grimac.internal.storage.checks.JdbcCheckCatalogPersistenceTest --tests ac.grim.grimac.internal.storage.backend.V2BackendIntegrationTest.sqlite --tests ac.grim.grimac.internal.storage.backend.V2BackendIntegrationTest.sqliteLegacy